### PR TITLE
Add dynamic Giscus comments embed

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2289,6 +2289,26 @@ footer {
     margin-bottom: 1.5rem;
 }
 
+.blog-comments .giscus,
+.blog-comments .giscus-placeholder,
+.blog-comments .giscus-noscript {
+    border-radius: 18px;
+    padding: 1.25rem 1.5rem;
+    background: rgba(148, 163, 184, 0.08);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.blog-comments .giscus-placeholder,
+.blog-comments .giscus-noscript {
+    color: var(--text-secondary, rgba(15, 23, 42, 0.7));
+    font-size: 0.95rem;
+}
+
+.blog-comments .giscus-noscript {
+    display: inline-block;
+    margin-top: 1rem;
+}
+
 .blog-related {
     margin-top: 4rem;
     padding: clamp(1.8rem, 3vw, 2.5rem);

--- a/templates/blog/detail.html
+++ b/templates/blog/detail.html
@@ -45,24 +45,74 @@
 
 <section class="blog-comments" aria-labelledby="comments-title">
     <h2 id="comments-title">Join the discussion</h2>
-    {% if giscus.repo and giscus.repo_id and giscus.category and giscus.category_id %}
-        <div class="giscus"></div>
-        <script id="giscus-script"
-                src="https://giscus.app/client.js"
-                data-repo="{{ giscus.repo }}"
-                data-repo-id="{{ giscus.repo_id }}"
-                data-category="{{ giscus.category }}"
-                data-category-id="{{ giscus.category_id }}"
-                data-mapping="{{ giscus.mapping }}"
-                data-strict="{{ giscus.strict }}"
-                data-reactions-enabled="{{ giscus.reactions_enabled }}"
-                data-emit-metadata="{{ giscus.emit_metadata }}"
-                data-input-position="{{ giscus.input_position }}"
-                data-theme="{{ giscus.theme_light }}"
-                data-lang="{{ giscus.lang }}"
-                data-loading="{{ giscus.loading }}"
-                crossorigin="anonymous"
-                async>
+    {% if giscus.enabled %}
+        {% set giscus_payload = {
+            'repo': giscus.repo,
+            'repo_id': giscus.repo_id,
+            'category': giscus.category,
+            'category_id': giscus.category_id,
+            'mapping': giscus.mapping,
+            'strict': giscus.strict,
+            'reactions_enabled': giscus.reactions_enabled,
+            'emit_metadata': giscus.emit_metadata,
+            'input_position': giscus.input_position,
+            'lang': giscus.lang,
+            'theme_light': giscus.theme_light,
+            'theme_dark': giscus.theme_dark,
+            'loading': giscus.loading
+        } %}
+        <div class="giscus" data-enabled="true"></div>
+        <script>
+            (function () {
+                const config = {{ giscus_payload | tojson }};
+                const requiredKeys = ['repo', 'repo_id', 'category', 'category_id'];
+                if (!requiredKeys.every((key) => config[key])) {
+                    return;
+                }
+
+                function preferredTheme() {
+                    try {
+                        const storedTheme = localStorage.getItem('theme');
+                        if (storedTheme === 'dark' || storedTheme === 'light') {
+                            return storedTheme;
+                        }
+                        if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                            return 'dark';
+                        }
+                    } catch (error) {
+                        console.warn('Unable to determine preferred theme for Giscus:', error);
+                    }
+                    return 'light';
+                }
+
+                const script = document.createElement('script');
+                script.id = 'giscus-script';
+                script.src = 'https://giscus.app/client.js';
+                script.async = true;
+                script.setAttribute('data-repo', config.repo);
+                script.setAttribute('data-repo-id', config.repo_id);
+                script.setAttribute('data-category', config.category);
+                script.setAttribute('data-category-id', config.category_id);
+                script.setAttribute('data-mapping', config.mapping || 'pathname');
+                script.setAttribute('data-strict', config.strict || '1');
+                script.setAttribute('data-reactions-enabled', config.reactions_enabled || '1');
+                script.setAttribute('data-emit-metadata', config.emit_metadata || '0');
+                script.setAttribute('data-input-position', config.input_position || 'bottom');
+                script.setAttribute('data-lang', config.lang || 'en');
+                script.setAttribute('data-loading', config.loading || 'lazy');
+                script.setAttribute(
+                    'data-theme',
+                    preferredTheme() === 'dark' ? config.theme_dark : config.theme_light
+                );
+                script.setAttribute('crossorigin', 'anonymous');
+
+                const container = document.querySelector('.giscus');
+                if (!container) {
+                    return;
+                }
+                container.innerHTML = '';
+                container.appendChild(script);
+            })();
         </script>
         <noscript class="giscus-noscript">Enable JavaScript to view comments powered by Giscus.</noscript>
     {% else %}
@@ -91,7 +141,7 @@
 {% endblock %}
 
 {% block scripts %}
-    {% if giscus.repo and giscus.repo_id and giscus.category and giscus.category_id %}
+    {% if giscus.enabled %}
         <script>
             (function () {
                 const DARK_THEME = '{{ giscus.theme_dark }}';
@@ -129,10 +179,6 @@
 
                 document.addEventListener('DOMContentLoaded', function () {
                     const initialTheme = currentTheme();
-                    const giscusScript = document.getElementById('giscus-script');
-                    if (giscusScript) {
-                        giscusScript.setAttribute('data-theme', resolveGiscusTheme(initialTheme));
-                    }
 
                     const observer = new MutationObserver(function () {
                         const iframe = document.querySelector('iframe.giscus-frame');

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,6 @@
 import pytest
 
+import app as app_module
 from app import app
 from blog import load_posts
 
@@ -55,3 +56,36 @@ def test_blog_detail(client):
     response = client.get('/blog/how-i-teach-game-development/')
     assert response.status_code == 200
     assert b'How I Teach Game Development' in response.data
+
+
+def test_blog_detail_comments_placeholder(client):
+    response = client.get('/blog/how-i-teach-game-development/')
+    assert b'Join the discussion' in response.data
+    assert b'giscus-placeholder' in response.data
+
+
+def test_blog_detail_giscus_embed(monkeypatch, client):
+    monkeypatch.setitem(
+        app_module.SITE_CONFIG,
+        'giscus',
+        {
+            'repo': 'octocat/example',
+            'repo_id': 'R_123',
+            'category': 'Announcements',
+            'category_id': 'DIC_456',
+            'mapping': 'pathname',
+            'strict': '1',
+            'reactions_enabled': '1',
+            'emit_metadata': '0',
+            'input_position': 'bottom',
+            'lang': 'en',
+            'theme_light': 'light',
+            'theme_dark': 'dark',
+            'loading': 'lazy',
+            'enabled': True,
+        },
+    )
+
+    response = client.get('/blog/how-i-teach-game-development/')
+    assert b'https://giscus.app/client.js' in response.data
+    assert b'const config =' in response.data


### PR DESCRIPTION
## Summary
- add a helper to normalise Giscus-related environment values and expose an `enabled` flag in the site config
- dynamically inject the Giscus client with theme-aware defaults and style the comments placeholder/noscript states
- cover the placeholder and configured embed in the blog detail view with new tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4c0086044832cad7077ab6e0c61c1