### PR TITLE
Add media upload workflow to blog authoring tool

### DIFF
--- a/authoring_app/__init__.py
+++ b/authoring_app/__init__.py
@@ -11,16 +11,43 @@ from .views import bp as authoring_bp
 def create_app() -> Flask:
     """Application factory for the authoring tool."""
     app = Flask(__name__, template_folder='templates')
+
+    project_root = Path(__file__).resolve().parent.parent
+    static_root = project_root / 'static'
+    default_media_dir = static_root / 'uploads'
+
     app.config.from_mapping(
         SECRET_KEY=os.getenv('AUTHORING_SECRET_KEY', 'dev-authoring-secret'),
         CONTENT_DIR=get_content_dir(
             os.getenv('AUTHORING_CONTENT_DIR')
         ).resolve(),
+        STATIC_ROOT=static_root.resolve(),
+        MEDIA_UPLOAD_DIR=Path(
+            os.getenv('AUTHORING_MEDIA_DIR', default_media_dir)
+        ).resolve(),
+        MEDIA_URL_PREFIX=os.getenv('AUTHORING_MEDIA_URL_PREFIX', '/static/uploads'),
+        ALLOWED_MEDIA_EXTENSIONS={
+            'png',
+            'jpg',
+            'jpeg',
+            'gif',
+            'webp',
+            'svg',
+            'mp4',
+            'mov',
+            'webm',
+            'ogv',
+            'mp3',
+            'wav',
+        },
     )
 
     # Ensure content directory exists so authors can start immediately
     content_dir: Path = app.config['CONTENT_DIR']
     content_dir.mkdir(parents=True, exist_ok=True)
+
+    media_dir: Path = app.config['MEDIA_UPLOAD_DIR']
+    media_dir.mkdir(parents=True, exist_ok=True)
 
     app.register_blueprint(authoring_bp)
 

--- a/authoring_app/templates/authoring/edit.html
+++ b/authoring_app/templates/authoring/edit.html
@@ -5,6 +5,29 @@
         <h2>{{ 'Create Post' if is_new else 'Edit Post' }}</h2>
     </header>
 
+    <section class="media-upload">
+        <h3>Upload images, video, or audio</h3>
+        <p>
+            Use this uploader to add media files to
+            <code>{{ media_url_prefix }}</code>. After the upload completes, copy
+            the flashed URL into the Hero image field or embed it in your
+            Markdown using standard Markdown image syntax or an HTML
+            <code>&lt;video&gt;</code>/<code>&lt;audio&gt;</code> tag.
+        </p>
+        <form
+            method="post"
+            action="{{ url_for('authoring.upload_media') }}"
+            enctype="multipart/form-data"
+        >
+            <input type="hidden" name="next" value="{{ request.full_path }}">
+            <label>
+                Choose file
+                <input name="media_file" type="file" required>
+            </label>
+            <button type="submit">Upload media</button>
+        </form>
+    </section>
+
     <form method="post">
         <input type="hidden" name="original_slug" value="{{ post_data.original_slug }}">
         <label>

--- a/tests/test_authoring_app.py
+++ b/tests/test_authoring_app.py
@@ -1,3 +1,5 @@
+import io
+
 import pytest
 
 from authoring_app import create_app
@@ -7,6 +9,7 @@ from authoring_app import create_app
 def authoring_client(tmp_path, monkeypatch):
     monkeypatch.setenv('AUTHORING_CONTENT_DIR', str(tmp_path))
     monkeypatch.setenv('AUTHORING_SECRET_KEY', 'test-secret')
+    monkeypatch.setenv('AUTHORING_MEDIA_DIR', str(tmp_path / 'uploads'))
     app = create_app()
     app.config.update(TESTING=True)
     with app.test_client() as client:
@@ -43,3 +46,24 @@ def test_create_post_writes_markdown(authoring_client, tmp_path):
     assert 'slug: my-first-post' in content
     assert '# Heading' in content
     assert 'tags:' not in content
+
+
+def test_upload_media_saves_file(authoring_client, tmp_path):
+    upload_path = tmp_path / 'uploads'
+    assert not any(upload_path.iterdir()) if upload_path.exists() else True
+
+    response = authoring_client.post(
+        '/authoring/uploads',
+        data={
+            'media_file': (io.BytesIO(b'fake image data'), 'photo.jpg'),
+            'next': '/authoring/posts/new',
+        },
+        content_type='multipart/form-data',
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+
+    saved_file = upload_path / 'photo.jpg'
+    assert saved_file.exists()
+    assert saved_file.read_bytes() == b'fake image data'


### PR DESCRIPTION
## Summary
- configure the authoring app with a shared static uploads directory and allowed media types
- add media upload endpoint and UI to surface usable URLs for images, video, and audio embeds
- cover the new workflow with tests for the upload handler and fixture configuration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fa8f0f2058832c82758e842261dea3