### PR TITLE
feat(design): blog redesign, about page, simplified home (#131)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `make freeze` — Generate static build into `build/`
 - `make docker-build` / `make docker-up` — Build/run production container (:3000)
 - `make authoring` — Start authoring CMS container (:5001)
-- `make deploy` — Deploy via GitHub Pages
+- `make deploy` — Freeze and deploy via GitHub Pages (`deploy-gh-pages.sh`)
+- `make clean` — Remove `build/` and `.pytest_cache`
 
 **Without Docker:**
 - `python app.py` — Dev server (Flask :5000)
@@ -22,23 +23,27 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Architecture
 
-The project has three distinct Flask applications that share templates and content:
+Three distinct Flask applications share templates and content:
 
-1. **`app.py`** — Main site. Serves all public routes (home, about, blog, contact). Static site config lives in `SITE_CONFIG` dict near the top.
+1. **`app.py`** — Main public site. Routes: `/`, `/blog/`, `/blog/<slug>/`, `/sitemap.xml`, `/robots.txt`. Site-wide config lives in the `SITE_CONFIG` dict near the top, populated from env vars. `build_page_context()` assembles the template context passed to every `render_template` call. Posts are loaded once per request via Flask's `g` object.
 
-2. **`freeze.py`** — Static site generator. Uses Flask's test client to render every route to HTML files in `build/`. Production deploys are this frozen output served by Nginx or GitHub Pages.
+2. **`freeze.py`** — Static site generator. Uses Flask's test client to render every route to HTML files in `build/`. Respects `GITHUB_PAGES_BASE_PATH` env var (distinct from `BASE_PATH`) to rewrite paths for subdirectory deployments. Production deploys serve this frozen output via Nginx or GitHub Pages.
 
-3. **`author_app.py`** + **`authoring_app/views.py`** — Separate CMS app (port 5001 in Docker). Provides a web UI for creating/editing Markdown blog posts and uploading media. Not part of the public site.
+3. **`author_app.py`** + **`authoring_app/`** — CMS app (port 5001). Uses an application factory (`create_app()` in `authoring_app/__init__.py`). Routes are in `authoring_app/views.py` under a Blueprint at `/authoring`. Handles Markdown post creation/editing and media uploads. Not part of the public site build.
 
 ### Blog Engine (`blog/`)
 - Posts live as Markdown files in `content/posts/` with YAML front matter (`title`, `slug`, `date`, optional `hero_image`)
 - `blog/utils.py` handles parsing, metadata extraction, and rendering (with syntax highlighting and safe HTML)
-- Content directory is configurable via env vars
+- Content directory resolves via: `BLOG_CONTENT_DIR` → `AUTHORING_CONTENT_DIR` → `CONTENT_DIR` env vars → default `content/posts/`
+
+### Tests (`tests/`)
+- `conftest.py` reloads the `app` module fresh for each test run to avoid import-order side effects — keep this in mind when writing fixtures that patch module-level state
+- Test files map roughly 1:1 to source files: `test_app.py`, `test_authoring_app.py`, `test_blog_utils.py`, `test_freeze_utils.py`
 
 ### Environment
 - Copy `.env.example` to `.env` (or `.env.dev` for dev mode)
 - `FLASK_ENV`/`APP_ENV` controls which env file loads
-- Key vars: `BASE_PATH` (for subdirectory deployments), `PLAUSIBLE_SCRIPT_URL` (optional analytics)
+- Key vars: `BASE_PATH` (subdirectory deployments), `GITHUB_PAGES_BASE_PATH` (static build path rewriting), `PLAUSIBLE_SCRIPT_URL` / `PLAUSIBLE_DOMAIN` (optional analytics)
 
 ## Git Commits
 Use [Conventional Commits](https://www.conventionalcommits.org/): `type(scope): description`

--- a/app.py
+++ b/app.py
@@ -29,12 +29,14 @@ SITE_CONFIG = {
 
 NAV_LINKS = [
     {'label': 'Home', 'href': '/'},
-    {'label': 'Blog', 'href': '/blog/'},
+    {'label': 'Writing', 'href': '/blog/'},
+    {'label': 'About', 'href': '/about/'},
 ]
 
 SITE_LINKS = {
     'home': '/',
     'blog': '/blog/',
+    'about': '/about/',
 }
 
 
@@ -95,13 +97,18 @@ def blog_detail(slug: str):
     )
 
 
+@app.route('/about/')
+def about():
+    return render_template('about.html', **build_page_context(page_slug='about'))
+
+
 @app.route('/sitemap.xml')
 def sitemap():
     posts = get_posts()
     today = datetime.utcnow().date().isoformat()
     urls = [
         {'loc': build_absolute_url(p), 'lastmod': today, 'changefreq': 'weekly'}
-        for p in ['/', '/blog/']
+        for p in ['/', '/blog/', '/about/']
     ] + [
         {
             'loc': build_absolute_url(f'/blog/{post["slug"]}/'),

--- a/freeze.py
+++ b/freeze.py
@@ -37,6 +37,7 @@ def build_static_site() -> None:
             static_routes = [
                 ('/', BUILD_DIR / 'index.html'),
                 ('/blog/', BUILD_DIR / 'blog' / 'index.html'),
+                ('/about/', BUILD_DIR / 'about' / 'index.html'),
             ]
             for route, destination in static_routes:
                 response = client.get(route)

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -12,7 +12,8 @@
     --wrap-width: 700px;
     --nav-height: 56px;
     --font-serif: 'Fraunces', Georgia, serif;
-    --font-sans: 'Newsreader', Georgia, serif;
+    --font-body: 'Newsreader', Georgia, serif;
+    --font-sans: system-ui, -apple-system, sans-serif;
     --font-mono: 'JetBrains Mono', 'SFMono-Regular', Menlo, monospace;
 }
 
@@ -28,7 +29,7 @@ html[data-theme="dark"] {
 html { scroll-behavior: smooth; }
 
 body {
-    font-family: var(--font-serif);
+    font-family: var(--font-body);
     font-size: 1.125rem;
     line-height: 1.8;
     color: var(--text);
@@ -262,13 +263,6 @@ footer a:hover { color: var(--text); opacity: 1; }
         font-size: 1.1rem;
         color: var(--text);
     }
-
-    .post-list time {
-        min-width: 5rem;
-        font-size: 0.75rem;
-    }
-
-    .post-list a { font-size: 0.9rem; }
 
     .blog-post-body { font-size: 1rem; }
 

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -11,8 +11,8 @@
     --nav-bg: rgba(250, 250, 248, 0.95);
     --wrap-width: 700px;
     --nav-height: 56px;
-    --font-serif: 'Lora', Georgia, serif;
-    --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+    --font-serif: 'Fraunces', Georgia, serif;
+    --font-sans: 'Newsreader', Georgia, serif;
     --font-mono: 'JetBrains Mono', 'SFMono-Regular', Menlo, monospace;
 }
 

--- a/static/css/components-blog.css
+++ b/static/css/components-blog.css
@@ -1,228 +1,366 @@
-/* Blog layout */
-.blog-main { padding: 3rem 0 5rem; }
+/* ── Blog shared ─────────────────────────────────────────────────────────────── */
+.blog-main { padding: 4rem 0 6rem; }
 
-/* Post list (used on home and blog/list) */
-.post-list {
-    list-style: none;
-    margin: 1.5rem 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0;
-}
-
-.post-list li {
-    display: flex;
-    align-items: baseline;
-    gap: 1.25rem;
-    padding: 0.5rem 0;
-    border-bottom: 1px solid var(--border);
-}
-
-.post-list li:first-child { border-top: 1px solid var(--border); }
-
-.post-list time {
-    font-family: var(--font-sans);
-    font-size: 0.8rem;
-    color: var(--text-muted);
-    white-space: nowrap;
-    flex-shrink: 0;
-    min-width: 6.5rem;
-}
-
-.post-list a {
-    font-family: var(--font-sans);
-    color: var(--text);
-    text-decoration: none;
-    font-size: 0.9375rem;
-    line-height: 1.4;
-}
-
-.post-list a:hover {
-    color: var(--accent);
-    opacity: 1;
-}
-
-/* Blog list page */
+/* ── Blog list header ────────────────────────────────────────────────────────── */
 .blog-list-header {
-    margin-bottom: 2rem;
+    margin-bottom: 3rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid var(--border);
 }
 
 .blog-list-header h1 {
     font-family: var(--font-serif);
-    font-size: 1.5rem;
+    font-size: clamp(2rem, 5vw, 2.75rem);
     font-weight: 600;
-    margin-bottom: 0.35rem;
-    letter-spacing: -0.02em;
+    letter-spacing: -0.03em;
+    margin-bottom: 0.5rem;
+    line-height: 1.1;
 }
 
 .blog-list-header p {
     font-family: var(--font-sans);
     font-size: 0.875rem;
     color: var(--text-muted);
+    letter-spacing: 0.01em;
+}
+
+/* ── Post list ───────────────────────────────────────────────────────────────── */
+.post-list {
+    list-style: none;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.post-list li + li {
+    border-top: 1px solid var(--border);
+}
+
+.post-list .post-link {
+    display: block;
+    padding: 1.4rem 0 1.4rem 1.1rem;
+    text-decoration: none;
+    color: var(--text);
+    position: relative;
+    transition: padding-left 0.2s ease;
+}
+
+.post-list .post-link::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    height: 55%;
+    width: 2px;
+    background: var(--accent);
+    opacity: 0;
+    border-radius: 1px;
+    transition: opacity 0.18s ease;
+}
+
+.post-list .post-link:hover {
+    padding-left: 1.6rem;
+}
+
+.post-list .post-link:hover::before {
+    opacity: 1;
+}
+
+.post-list time {
+    display: block;
+    font-family: var(--font-sans);
+    font-size: 0.68rem;
+    color: var(--text-muted);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    margin-bottom: 0.3rem;
+}
+
+.post-list .post-title {
+    display: block;
+    font-family: var(--font-serif);
+    font-size: 1.1rem;
+    font-weight: 600;
+    line-height: 1.4;
+    letter-spacing: -0.01em;
+    color: var(--text);
+    transition: color 0.15s;
+}
+
+.post-list .post-link:hover .post-title {
+    color: var(--accent);
 }
 
 .blog-empty {
     color: var(--text-muted);
     font-size: 0.95rem;
     margin-top: 2rem;
+    font-family: var(--font-sans);
 }
 
-/* Blog post */
-.blog-post { max-width: 68ch; }
+/* ── Post back-link ──────────────────────────────────────────────────────────── */
+.blog-post-nav {
+    margin-bottom: 2.5rem;
+}
 
-.blog-post-header { margin-bottom: 2rem; }
-
-.blog-post-date {
+.back-link {
     font-family: var(--font-sans);
     font-size: 0.8rem;
     color: var(--text-muted);
-    margin-bottom: 0.75rem;
-    letter-spacing: 0.01em;
+    text-decoration: none;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    transition: color 0.15s;
 }
+
+.back-link:hover {
+    color: var(--accent);
+    opacity: 1;
+}
+
+/* ── Post header ─────────────────────────────────────────────────────────────── */
+.blog-post { max-width: 70ch; }
+
+.blog-post-header { margin-bottom: 2.5rem; }
 
 .blog-post-header h1 {
-    font-size: clamp(1.35rem, 5vw, 2.25rem);
-    line-height: 1.25;
-    letter-spacing: -0.02em;
+    font-size: clamp(1.6rem, 5vw, 2.4rem);
+    line-height: 1.2;
+    letter-spacing: -0.025em;
+    margin-bottom: 1rem;
 }
 
+.blog-post-date {
+    font-family: var(--font-sans);
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+}
+
+.blog-post-divider {
+    color: var(--border);
+}
+
+/* ── Hero image ──────────────────────────────────────────────────────────────── */
 .blog-post-hero {
-    margin: 2rem 0;
-    border-radius: 6px;
+    margin: 2.5rem 0;
+    border-radius: 4px;
     overflow: hidden;
+    border: 1px solid var(--border);
 }
 
 .blog-post-hero img { width: 100%; height: auto; display: block; }
 
-/* Post body prose */
+/* ── Post body prose ─────────────────────────────────────────────────────────── */
 .blog-post-body {
-    font-size: 1.05rem;
-    line-height: 1.8;
+    font-size: 1.0625rem;
+    line-height: 1.82;
 }
 
-.blog-post-body > * + * { margin-top: 1.4rem; }
+.blog-post-body > * + * { margin-top: 1.5rem; }
 
 .blog-post-body h2,
 .blog-post-body h3,
 .blog-post-body h4 {
-    margin-top: 2.5rem;
-    margin-bottom: 0.75rem;
+    margin-top: 2.75rem;
+    margin-bottom: 0.6rem;
     line-height: 1.3;
-    letter-spacing: -0.01em;
+    letter-spacing: -0.015em;
 }
 
-.blog-post-body h2 { font-size: 1.35rem; }
-.blog-post-body h3 { font-size: 1.15rem; }
+.blog-post-body h2 {
+    font-size: 1.3rem;
+    padding-bottom: 0.4rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.blog-post-body h3 { font-size: 1.1rem; }
 .blog-post-body h4 { font-size: 1rem; }
 
-.blog-post-body a { color: var(--accent); }
+.blog-post-body a {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    text-decoration-thickness: 1px;
+}
+
+.blog-post-body a:hover { opacity: 0.75; }
 
 .blog-post-body ul,
 .blog-post-body ol {
     padding-left: 1.5rem;
 }
 
-.blog-post-body li + li { margin-top: 0.35rem; }
+.blog-post-body li + li { margin-top: 0.4rem; }
 
 .blog-post-body blockquote {
-    border-left: 3px solid var(--border);
-    padding-left: 1rem;
-    color: var(--text-muted);
+    margin: 2rem 0;
+    padding: 1.25rem 1.5rem;
+    border-left: 3px solid var(--accent);
+    background: color-mix(in srgb, var(--accent) 5%, transparent);
+    border-radius: 0 4px 4px 0;
+    color: var(--text);
     font-style: italic;
-    margin: 1.5rem 0;
 }
+
+.blog-post-body blockquote p { color: inherit; }
 
 .blog-post-body code {
     font-family: var(--font-mono);
-    font-size: 0.85em;
-    background: color-mix(in srgb, var(--text) 8%, transparent);
-    padding: 0.15em 0.35em;
+    font-size: 0.82em;
+    background: color-mix(in srgb, var(--text) 7%, transparent);
+    padding: 0.15em 0.4em;
     border-radius: 3px;
+    border: 1px solid var(--border);
 }
 
 .blog-post-body pre {
-    background: color-mix(in srgb, var(--text) 6%, transparent);
-    padding: 1.25rem;
+    background: color-mix(in srgb, var(--text) 5%, transparent);
+    padding: 1.35rem 1.5rem;
     border-radius: 6px;
     overflow-x: auto;
-    margin: 1.5rem 0;
+    margin: 1.75rem 0;
     border: 1px solid var(--border);
 }
 
 .blog-post-body pre code {
     background: none;
     padding: 0;
-    font-size: 0.875rem;
-    line-height: 1.6;
+    border: none;
+    font-size: 0.855rem;
+    line-height: 1.65;
 }
 
 .blog-post-body img {
     max-width: 100%;
     height: auto;
     border-radius: 4px;
+    border: 1px solid var(--border);
 }
 
 .blog-post-body hr {
     border: none;
     border-top: 1px solid var(--border);
-    margin: 2.5rem 0;
+    margin: 3rem 0;
 }
 
 .blog-post-body table {
     width: 100%;
     border-collapse: collapse;
-    font-size: 0.95rem;
+    font-size: 0.93rem;
+    font-family: var(--font-sans);
 }
 
 .blog-post-body th,
 .blog-post-body td {
-    padding: 0.6rem 0.75rem;
+    padding: 0.6rem 0.8rem;
     text-align: left;
     border-bottom: 1px solid var(--border);
 }
 
-.blog-post-body th { font-weight: 600; }
+.blog-post-body th {
+    font-weight: 600;
+    font-size: 0.72rem;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+}
 
-/* Related posts */
+/* ── Related posts ───────────────────────────────────────────────────────────── */
 .blog-related {
-    margin-top: 4rem;
-    padding-top: 2rem;
+    margin-top: 5rem;
+    padding-top: 2.5rem;
     border-top: 1px solid var(--border);
-    max-width: 68ch;
+    max-width: 70ch;
 }
 
 .blog-related h2 {
     font-family: var(--font-sans);
-    font-size: 0.75rem;
+    font-size: 0.68rem;
     font-weight: 500;
-    margin-bottom: 1rem;
+    margin-bottom: 1.5rem;
     color: var(--text-muted);
     text-transform: uppercase;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.1em;
 }
 
 .blog-related ul {
     list-style: none;
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0;
+}
+
+.blog-related li + li {
+    border-top: 1px solid var(--border);
 }
 
 .blog-related a {
     display: flex;
     flex-direction: column;
-    gap: 0.1rem;
+    gap: 0.15rem;
     text-decoration: none;
     color: var(--text);
-    padding: 0.25rem 0;
+    padding: 1rem 0 1rem 1rem;
+    position: relative;
+    transition: padding-left 0.2s ease;
 }
 
-.blog-related a:hover { color: var(--accent); opacity: 1; }
+.blog-related a::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    height: 55%;
+    width: 2px;
+    background: var(--accent);
+    opacity: 0;
+    border-radius: 1px;
+    transition: opacity 0.18s ease;
+}
 
-.related-title { font-size: 0.95rem; }
+.blog-related a:hover {
+    padding-left: 1.5rem;
+    opacity: 1;
+}
+
+.blog-related a:hover::before { opacity: 1; }
+
+.related-title {
+    font-family: var(--font-serif);
+    font-size: 0.975rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    transition: color 0.15s;
+}
+
+.blog-related a:hover .related-title { color: var(--accent); }
 
 .related-meta {
     font-family: var(--font-sans);
-    font-size: 0.775rem;
+    font-size: 0.7rem;
     color: var(--text-muted);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+/* ── Mobile ──────────────────────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+    .blog-main { padding: 2.5rem 0 4rem; }
+
+    .blog-list-header { margin-bottom: 2rem; padding-bottom: 1.5rem; }
+
+    .blog-post-body { font-size: 1rem; }
+
+    .blog-post-body h2 { font-size: 1.15rem; }
+    .blog-post-body h3 { font-size: 1rem; }
+
+    .post-list .post-link { padding: 1.1rem 0 1.1rem 1rem; }
+    .post-list .post-link:hover { padding-left: 1.4rem; }
 }

--- a/static/css/components-core.css
+++ b/static/css/components-core.css
@@ -1322,3 +1322,79 @@ section h2 {
         display: none;
     }
 }
+
+/* ── Home page ───────────────────────────────────────────────────────────────── */
+.home-intro { padding-top: 3rem; }
+
+.home-intro h1 {
+    font-family: var(--font-serif);
+    font-size: clamp(2rem, 5vw, 2.75rem);
+    font-weight: 600;
+    letter-spacing: -0.03em;
+    line-height: 1.1;
+    margin-bottom: 1.25rem;
+}
+
+.home-intro > p {
+    font-size: 1.0625rem;
+    line-height: 1.75;
+    color: var(--text-muted);
+    max-width: 52ch;
+    margin-bottom: 2rem;
+}
+
+.home-links {
+    display: flex;
+    gap: 2rem;
+}
+
+.home-links a {
+    font-family: var(--font-sans);
+    font-size: 0.95rem;
+    color: var(--text);
+    text-decoration: none;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 1px;
+    transition: color 0.15s, border-color 0.15s;
+}
+
+.home-links a:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+    opacity: 1;
+}
+
+/* ── About page ──────────────────────────────────────────────────────────────── */
+.about-page { max-width: 60ch; }
+
+.about-header {
+    margin-bottom: 2.5rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.about-avatar {
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    object-fit: cover;
+    display: block;
+    margin-bottom: 1.25rem;
+    border: 2px solid var(--border);
+}
+
+.about-header h1 {
+    font-family: var(--font-serif);
+    font-size: clamp(2rem, 5vw, 2.75rem);
+    font-weight: 600;
+    letter-spacing: -0.03em;
+    line-height: 1.1;
+}
+
+.about-body p {
+    font-size: 1.0625rem;
+    line-height: 1.82;
+    max-width: 60ch;
+}
+
+.about-body p + p { margin-top: 1.4rem; }

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+
+{% block title %}About | {{ config.name }}{% endblock %}
+{% block meta_description %}About {{ config.name }} — full-stack developer writing about software, tools, and building things.{% endblock %}
+
+{% block content %}
+<article class="about-page">
+    <header class="about-header">
+        <img src="{{ url_for('static', filename='images/SreyeeshProfilePic.jpg') }}" alt="Sreyeesh Garimella" class="about-avatar">
+        <h1>About</h1>
+    </header>
+
+    <div class="about-body">
+        <p>
+            I'm Sreyeesh Garimella — a full-stack developer and technical artist based in Estonia.
+            I've worked across games, animation, and software, building pipelines and tools at studios
+            including DNEG, Blizzard, and Walt Disney Animation.
+        </p>
+        <p>
+            These days I'm focused on software and tooling — the kind of work that makes other
+            work easier. I write here about things I'm building, thinking through, or learning.
+            No particular cadence. Just when something is worth saying.
+        </p>
+        <p>
+            If you want to get in touch, email is the best way:
+            <a href="mailto:{{ config.email }}">{{ config.email }}</a>
+        </p>
+    </div>
+</article>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,7 +32,7 @@
             } catch (err) {}
         })();
     </script>
-    <link href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,600;1,400&family=Inter:wght@400;500&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;1,9..144,400&family=Newsreader:ital,wght@0,400;0,500;1,400&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css', v=config.asset_version) }}">
     {% if config.plausible_script_url %}
         <script

--- a/templates/blog/detail.html
+++ b/templates/blog/detail.html
@@ -1,6 +1,6 @@
 {% extends 'blog/base.html' %}
 
-{% block title %}{{ post.title }} — {{ config.name }} Blog{% endblock %}
+{% block title %}{{ post.title }} — {{ config.name }} Blog{% endblock %}
 {% block meta_description %}{{ post.description or post.excerpt }}{% endblock %}
 
 {% block social_meta %}
@@ -87,4 +87,4 @@
         {% endif %}
     </ul>
 </aside>
-{% endblock %}
+    {% endblock %}

--- a/templates/blog/detail.html
+++ b/templates/blog/detail.html
@@ -45,7 +45,7 @@
 
 {% block content %}
 <nav class="blog-post-nav">
-    <a href="{{ blog_index_href }}" class="back-link">← Writing</a>
+    <a href="{{ site_links.blog }}" class="back-link">← Writing</a>
 </nav>
 
 <article class="blog-post">
@@ -76,7 +76,7 @@
         {% if related %}
             {% for other in related %}
                 <li>
-                    <a href="{{ blog_index_href }}{{ other.slug }}/">
+                    <a href="{{ site_links.blog }}{{ other.slug }}/">
                         <span class="related-title">{{ other.title }}</span>
                         <span class="related-meta">{{ other.date_display }} • {{ other.reading_time }} min read</span>
                     </a>

--- a/templates/blog/detail.html
+++ b/templates/blog/detail.html
@@ -44,10 +44,18 @@
 {% endblock %}
 
 {% block content %}
+<nav class="blog-post-nav">
+    <a href="{{ blog_index_href }}" class="back-link">← Writing</a>
+</nav>
+
 <article class="blog-post">
     <header class="blog-post-header">
-        <p class="blog-post-date">{{ post.date_display }} • {{ post.reading_time }} min read</p>
         <h1>{{ post.title }}</h1>
+        <p class="blog-post-date">
+            <time>{{ post.date_display }}</time>
+            <span class="blog-post-divider">·</span>
+            <span>{{ post.reading_time }} min read</span>
+        </p>
     </header>
 
     {% if post.hero_image %}

--- a/templates/blog/list.html
+++ b/templates/blog/list.html
@@ -12,8 +12,10 @@
 <ul class="post-list">
     {% for post in posts %}
     <li>
-        <time>{{ post.date_display }}</time>
-        <a href="{{ blog_index_href }}{{ post.slug }}/">{{ post.title }}</a>
+        <a class="post-link" href="{{ blog_index_href }}{{ post.slug }}/">
+            <time>{{ post.date_display }}</time>
+            <span class="post-title">{{ post.title }}</span>
+        </a>
     </li>
     {% endfor %}
 </ul>

--- a/templates/home.html
+++ b/templates/home.html
@@ -4,29 +4,15 @@
 {% block meta_description %}{{ config.meta_description }}{% endblock %}
 
 {% block content %}
-<section style="margin-bottom: 3rem;">
-    <h1 style="font-size: 1.35rem; font-weight: 700; margin-bottom: 0.75rem;">{{ config.name }}</h1>
-    <p style="color: var(--text-muted); font-size: 0.975rem;">
-        Full-stack developer. I write about software, tooling, and the craft of building things.
+<div class="home-intro">
+    <h1>{{ config.name }}</h1>
+    <p>
+        Full-stack developer and technical artist. I build tools,
+        write software, and occasionally write about it here.
     </p>
-</section>
-
-{% if posts %}
-<section>
-    <h2 style="font-family: system-ui, sans-serif; font-size: 0.8rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-muted); margin-bottom: 0.5rem;">Writing</h2>
-    <ul class="post-list">
-        {% for post in posts[:5] %}
-        <li>
-            <time>{{ post.date_display }}</time>
-            <a href="{{ site_links.blog }}{{ post.slug }}/">{{ post.title }}</a>
-        </li>
-        {% endfor %}
-    </ul>
-    {% if posts|length > 5 %}
-    <p style="margin-top: 1rem; font-size: 0.875rem;">
-        <a href="{{ site_links.blog }}">All posts →</a>
-    </p>
-    {% endif %}
-</section>
-{% endif %}
+    <nav class="home-links">
+        <a href="{{ site_links.blog }}">Writing →</a>
+        <a href="{{ site_links.about }}">About →</a>
+    </nav>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Swap fonts to Fraunces (display) + Newsreader (body) for a distinctive editorial feel
- Redesign blog list with stacked date/title layout and accent bar hover effect
- Redesign blog post detail — back link, larger title, small-caps date, improved blockquotes and code blocks
- Add `/about/` page with profile photo, route, nav link, and sitemap entry
- Simplify home page to name, intro paragraph, and two navigation links

## Test plan
- [x] Visit `/` — name, intro, Writing and About links visible
- [x] Visit `/blog/` — stacked date/title layout, hover accent bar works
- [x] Visit a blog post — back link present, typography readable, dark mode correct
- [x] Visit `/about/` — profile image and copy render correctly
- [x] Check light and dark mode on all three pages
- [x] Verify `/sitemap.xml` includes `/about/`

Closes #131