### PR TITLE
feat(authoring): redesign authoring tool UX (#130)

### DIFF
--- a/authoring_app/templates/authoring/base.html
+++ b/authoring_app/templates/authoring/base.html
@@ -7,37 +7,116 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@1/css/pico.min.css">
     {% block extra_head %}{% endblock %}
     <style>
+        /* ── Design tokens — light defaults ── */
+        :root {
+            --surface:       #ffffff;
+            --surface-2:     #f9fafb;
+            --surface-3:     #f3f4f6;
+            --border:        #e5e7eb;
+            --border-strong: #d1d5db;
+            --text:          #111827;
+            --text-2:        #374151;
+            --text-muted:    #6b7280;
+            --text-faint:    #9ca3af;
+            --accent:        #6366f1;
+            --btn-bg:        #ffffff;
+            --btn-text:      #374151;
+            --btn-border:    #d1d5db;
+            --btn-hover:     #e5e7eb;
+            --badge-draft-bg:   #fef9c3; --badge-draft-text:   #854d0e;
+            --badge-pub-bg:     #dcfce7; --badge-pub-text:     #166534;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --surface:       #111827;
+                --surface-2:     #1f2937;
+                --surface-3:     #374151;
+                --border:        #374151;
+                --border-strong: #4b5563;
+                --text:          #f9fafb;
+                --text-2:        #e5e7eb;
+                --text-muted:    #9ca3af;
+                --text-faint:    #6b7280;
+                --accent:        #818cf8;
+                --btn-bg:        #1f2937;
+                --btn-text:      #e5e7eb;
+                --btn-border:    #4b5563;
+                --btn-hover:     #374151;
+                --badge-draft-bg:   #422006; --badge-draft-text:   #fef08a;
+                --badge-pub-bg:     #052e16; --badge-pub-text:     #86efac;
+            }
+        }
+
         body { max-width: 1100px; margin: 0 auto; padding: 2rem 1.5rem; }
         header { margin-bottom: 2rem; }
+
         .flash { padding: 0.75rem 1rem; margin-bottom: 1rem; border-radius: 6px; }
         .flash-success { background: #e6f4ea; color: #1f7a1f; }
-        .flash-error { background: #fde8e8; color: #b91c1c; }
+        .flash-error   { background: #fde8e8; color: #b91c1c; }
+
+        @media (prefers-color-scheme: dark) {
+            .flash-success { background: #052e16; color: #86efac; }
+            .flash-error   { background: #450a0a; color: #fca5a5; }
+        }
+
         textarea { min-height: 260px; }
         .actions { display: flex; gap: 0.75rem; flex-wrap: wrap; }
+
+        /* ── Dashboard table ── */
         .post-list table { width: 100%; }
-        .md-toolbar { display: flex; flex-wrap: wrap; gap: 0.25rem; margin-bottom: 0.25rem; }
+
+        /* ── Toolbar (base — edit.html overrides with !important) ── */
+        .md-toolbar {
+            display: flex;
+            flex-direction: row;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 0.2rem;
+        }
         .md-toolbar button {
-            padding: 0.25rem 0.6rem; font-size: 0.8rem; font-weight: 600;
-            background: #f3f4f6; border: 1px solid #d1d5db; border-radius: 4px;
-            cursor: pointer; color: #374151;
+            padding: 0.25rem 0.6rem;
+            font-size: 0.8rem;
+            font-weight: 600;
+            background: var(--btn-bg);
+            border: 1px solid var(--btn-border);
+            border-radius: 4px;
+            cursor: pointer;
+            color: var(--btn-text);
         }
-        .md-toolbar button:hover { background: #e5e7eb; }
+        .md-toolbar button:hover { background: var(--btn-hover); }
+
+        /* ── Status badges ── */
         .status-badge {
-            display: inline-block; padding: 0.15rem 0.5rem; border-radius: 12px;
-            font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em;
+            display: inline-block;
+            padding: 0.15rem 0.5rem;
+            border-radius: 12px;
+            font-size: 0.75rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
         }
-        .status-draft     { background: #fef9c3; color: #854d0e; }
-        .status-published { background: #dcfce7; color: #166534; }
-        .media-upload { border: 1px solid #e5e7eb; border-radius: 6px; padding: 0.75rem 1rem; margin-bottom: 1.5rem; }
-        .media-upload summary { cursor: pointer; font-weight: 600; color: #374151; }
+        .status-draft     { background: var(--badge-draft-bg); color: var(--badge-draft-text); }
+        .status-published { background: var(--badge-pub-bg);   color: var(--badge-pub-text); }
+
+        /* ── Media gallery ── */
         .media-gallery { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.5rem; }
         .media-gallery .media-item {
-            width: 80px; height: 80px; border: 2px solid #e5e7eb; border-radius: 4px;
-            overflow: hidden; cursor: pointer; display: flex; align-items: center;
-            justify-content: center; background: #f9fafb; font-size: 0.65rem; text-align: center;
+            width: 80px; height: 80px;
+            border: 2px solid var(--border);
+            border-radius: 4px;
+            overflow: hidden;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: var(--surface-2);
+            font-size: 0.65rem;
+            text-align: center;
             padding: 0.2rem;
+            color: var(--text-muted);
         }
-        .media-gallery .media-item:hover { border-color: #6366f1; }
+        .media-gallery .media-item:hover { border-color: var(--accent); }
         .media-gallery .media-item img { width: 100%; height: 100%; object-fit: cover; }
     </style>
 </head>

--- a/authoring_app/templates/authoring/base.html
+++ b/authoring_app/templates/authoring/base.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Authoring Tool</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@1/css/pico.min.css">
+    {% block extra_head %}{% endblock %}
     <style>
         body { max-width: 1100px; margin: 0 auto; padding: 2rem 1.5rem; }
         header { margin-bottom: 2rem; }

--- a/authoring_app/templates/authoring/base.html
+++ b/authoring_app/templates/authoring/base.html
@@ -21,6 +21,12 @@
             cursor: pointer; color: #374151;
         }
         .md-toolbar button:hover { background: #e5e7eb; }
+        .status-badge {
+            display: inline-block; padding: 0.15rem 0.5rem; border-radius: 12px;
+            font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em;
+        }
+        .status-draft     { background: #fef9c3; color: #854d0e; }
+        .status-published { background: #dcfce7; color: #166534; }
     </style>
 </head>
 <body>

--- a/authoring_app/templates/authoring/base.html
+++ b/authoring_app/templates/authoring/base.html
@@ -14,6 +14,13 @@
         textarea { min-height: 260px; }
         .actions { display: flex; gap: 0.75rem; flex-wrap: wrap; }
         .post-list table { width: 100%; }
+        .md-toolbar { display: flex; flex-wrap: wrap; gap: 0.25rem; margin-bottom: 0.25rem; }
+        .md-toolbar button {
+            padding: 0.25rem 0.6rem; font-size: 0.8rem; font-weight: 600;
+            background: #f3f4f6; border: 1px solid #d1d5db; border-radius: 4px;
+            cursor: pointer; color: #374151;
+        }
+        .md-toolbar button:hover { background: #e5e7eb; }
     </style>
 </head>
 <body>

--- a/authoring_app/templates/authoring/base.html
+++ b/authoring_app/templates/authoring/base.html
@@ -38,5 +38,6 @@
     <main>
         {% block content %}{% endblock %}
     </main>
+    {% block extra_scripts %}{% endblock %}
 </body>
 </html>

--- a/authoring_app/templates/authoring/base.html
+++ b/authoring_app/templates/authoring/base.html
@@ -27,6 +27,17 @@
         }
         .status-draft     { background: #fef9c3; color: #854d0e; }
         .status-published { background: #dcfce7; color: #166534; }
+        .media-upload { border: 1px solid #e5e7eb; border-radius: 6px; padding: 0.75rem 1rem; margin-bottom: 1.5rem; }
+        .media-upload summary { cursor: pointer; font-weight: 600; color: #374151; }
+        .media-gallery { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.5rem; }
+        .media-gallery .media-item {
+            width: 80px; height: 80px; border: 2px solid #e5e7eb; border-radius: 4px;
+            overflow: hidden; cursor: pointer; display: flex; align-items: center;
+            justify-content: center; background: #f9fafb; font-size: 0.65rem; text-align: center;
+            padding: 0.2rem;
+        }
+        .media-gallery .media-item:hover { border-color: #6366f1; }
+        .media-gallery .media-item img { width: 100%; height: 100%; object-fit: cover; }
     </style>
 </head>
 <body>

--- a/authoring_app/templates/authoring/edit.html
+++ b/authoring_app/templates/authoring/edit.html
@@ -1,144 +1,415 @@
 {% extends 'authoring/base.html' %}
-{% block content %}
-<section>
-    <header>
-        <h2>{{ 'Create Post' if is_new else 'Edit Post' }}</h2>
-    </header>
-
-    <details class="media-upload">
-        <summary>Media uploads</summary>
-        <form
-            method="post"
-            action="{{ url_for('authoring.upload_media') }}"
-            enctype="multipart/form-data"
-            style="display:flex; gap:0.5rem; align-items:flex-end; flex-wrap:wrap; margin-bottom:0.75rem;"
-        >
-            <input type="hidden" name="next" value="{{ request.full_path }}">
-            <label style="margin:0; flex:1; min-width:200px;">
-                Choose file
-                <input name="media_file" type="file" required>
-            </label>
-            <button type="submit" style="margin:0;">Upload</button>
-        </form>
-        <div id="media-gallery" class="media-gallery">
-            <p style="color:#6b7280; font-size:0.85rem;">Loading uploads…</p>
-        </div>
-    </details>
-
-    <form method="post">
-        <input type="hidden" name="original_slug" value="{{ post_data.original_slug }}">
-        <label>
-            Title
-            <input id="title-input" name="title" type="text" value="{{ post_data.title }}" required>
-        </label>
-        <label>
-            Slug
-            <input id="slug-input" name="slug" type="text" value="{{ post_data.slug }}" placeholder="auto-from-title">
-            <small id="slug-preview" style="color: #6b7280; font-family: monospace;"></small>
-        </label>
-        <label>
-            Date
-            <input name="date" type="date" value="{{ post_data.date }}">
-        </label>
-        <label>
-            Description
-            <textarea name="description" rows="2">{{ post_data.description }}</textarea>
-        </label>
-        <label>
-            Excerpt
-            <textarea name="excerpt" rows="3">{{ post_data.excerpt }}</textarea>
-        </label>
-        <label>
-            Hero image URL
-            <input name="hero_image" type="text" value="{{ post_data.hero_image }}" placeholder="/static/uploads/hero.jpg">
-        </label>
-        <label>
-            Status
-            <select name="status">
-                <option value="draft" {% if post_data.status == 'draft' %}selected{% endif %}>Draft</option>
-                <option value="published" {% if post_data.status == 'published' %}selected{% endif %}>Published</option>
-            </select>
-        </label>
-        <label>
-            <input name="featured" type="checkbox" {% if post_data.featured %}checked{% endif %}> Featured post
-        </label>
-        <div class="editor-split">
-            <div class="editor-write">
-                <label>Content (Markdown)</label>
-                <div class="md-toolbar" id="md-toolbar">
-                    <button type="button" data-wrap="**" title="Bold">B</button>
-                    <button type="button" data-wrap="_" title="Italic">I</button>
-                    <button type="button" data-prefix="## " title="Heading">H2</button>
-                    <button type="button" data-prefix="### " title="Heading 3">H3</button>
-                    <button type="button" data-wrap="`" title="Inline code">Code</button>
-                    <button type="button" data-prefix="```\n" data-suffix="\n```" title="Code block">```</button>
-                    <button type="button" data-prefix="> " title="Blockquote">Quote</button>
-                    <button type="button" data-snippet="[link text](url)" title="Link">Link</button>
-                    <button type="button" data-snippet="![alt text](url)" title="Image">Img</button>
-                </div>
-                <textarea id="content-input" name="content" required>{{ post_data.content }}</textarea>
-            </div>
-            <div class="editor-preview">
-                <p class="preview-label">Live preview</p>
-                <div id="live-preview-output"></div>
-            </div>
-        </div>
-        <footer class="actions">
-            <button type="submit">Save post</button>
-            <a class="secondary" role="button" href="{{ url_for('authoring.dashboard') }}">Cancel</a>
-            {% if not is_new %}
-                <a class="secondary" role="button" href="{{ url_for('authoring.preview_post', slug=post_data.slug or post_data.original_slug) }}" target="_blank">Preview</a>
-            {% endif %}
-        </footer>
-    </form>
-</section>
-{% endblock %}
 
 {% block extra_head %}
 <style>
     body { max-width: 1400px !important; }
+
+    /* ── Editor-specific token overrides ── */
+    :root {
+        --editor-bg:   #1e1e2e;
+        --editor-text: #cdd6f4;
+    }
+    @media (prefers-color-scheme: dark) {
+        :root {
+            --editor-bg:   #0d1117;
+            --editor-text: #c9d1d9;
+        }
+    }
+
+    /* ── Top bar ── */
+    .editor-topbar {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        margin-bottom: 1.25rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+    }
+    .editor-topbar h2 { margin: 0; flex: 1; font-size: 1rem; color: var(--text-muted); font-weight: 600; }
+    .editor-topbar a  { margin: 0; font-size: 0.85rem; }
+
+    /* ── Title ── */
+    .title-field { margin-bottom: 0.75rem; }
+    .title-field input[type=text] {
+        width: 100%;
+        font-size: 1.75rem !important;
+        font-weight: 700 !important;
+        border: none !important;
+        border-bottom: 2px solid var(--border) !important;
+        border-radius: 0 !important;
+        padding: 0.25rem 0 !important;
+        background: transparent !important;
+        box-shadow: none !important;
+        outline: none;
+        color: var(--text) !important;
+    }
+    .title-field input[type=text]::placeholder { color: var(--border-strong); }
+    .title-field input[type=text]:focus { border-bottom-color: var(--accent) !important; }
+
+    /* ── Metadata row ── */
+    .meta-row {
+        display: flex !important;
+        flex-direction: row !important;
+        flex-wrap: wrap;
+        gap: 0.75rem 1.25rem;
+        align-items: flex-end;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 0.65rem 1rem;
+        margin-bottom: 0.65rem;
+    }
+    .meta-field { display: flex; flex-direction: column; gap: 0.15rem; }
+    .meta-field.grow { flex: 1; min-width: 180px; }
+    .meta-label {
+        font-size: 0.65rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+        color: var(--text-faint);
+    }
+    .meta-row input, .meta-row select { margin: 0 !important; padding: 0.3rem 0.5rem !important; font-size: 0.85rem !important; }
+    .meta-row small { font-family: monospace; font-size: 0.72rem; color: var(--text-muted); }
+    .meta-check { justify-content: flex-end; padding-bottom: 0.25rem; }
+    .meta-check label { display: flex; align-items: center; gap: 0.4rem; font-size: 0.875rem; margin: 0; white-space: nowrap; cursor: pointer; }
+    .meta-check input[type=checkbox] { margin: 0 !important; }
+
+    /* ── Extra metadata (collapsible) ── */
+    .extra-meta {
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 0.5rem 1rem;
+        margin-bottom: 0.75rem;
+        background: var(--surface-2);
+    }
+    .extra-meta summary { font-size: 0.82rem; color: var(--text-muted); cursor: pointer; padding: 0.2rem 0; }
+    .extra-meta-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 0.5rem 1rem;
+        margin-top: 0.75rem;
+    }
+    .extra-meta-grid .full { grid-column: 1 / -1; }
+    .extra-meta label { display: block; font-size: 0.78rem; font-weight: 600; color: var(--text-2); margin-bottom: 0.2rem; }
+    .extra-meta textarea, .extra-meta input { margin: 0 !important; font-size: 0.85rem !important; }
+    .extra-meta textarea { min-height: 64px; }
+
+    /* ── Toolbar ── */
+    .md-toolbar {
+        display: flex !important;
+        flex-direction: row !important;
+        flex-wrap: wrap !important;
+        align-items: center !important;
+        gap: 0.2rem;
+        padding: 0.45rem 0.6rem;
+        background: var(--surface-3);
+        border: 1px solid var(--border-strong);
+        border-bottom: none;
+        border-radius: 6px 6px 0 0;
+    }
+    .toolbar-group {
+        display: flex !important;
+        flex-direction: row !important;
+        gap: 0.15rem;
+    }
+    .toolbar-sep { width: 1px; height: 1.2rem; background: var(--border-strong); margin: 0 0.3rem; flex-shrink: 0; }
+    .md-toolbar button {
+        display: inline-flex !important;
+        flex-direction: row !important;
+        align-items: center;
+        justify-content: center;
+        padding: 0.2rem 0.55rem !important;
+        min-width: 2rem;
+        height: 1.75rem;
+        font-size: 0.8rem !important;
+        font-weight: 600;
+        background: var(--btn-bg) !important;
+        border: 1px solid var(--btn-border) !important;
+        border-radius: 4px !important;
+        color: var(--btn-text) !important;
+        cursor: pointer;
+        white-space: nowrap;
+        line-height: 1;
+        box-shadow: none !important;
+        margin: 0 !important;
+    }
+    .md-toolbar button:hover { background: var(--btn-hover) !important; border-color: var(--text-faint) !important; }
+    .md-toolbar button:active { background: var(--surface-3) !important; }
+
+    /* ── Split editor ── */
     .editor-split {
-        display: flex; gap: 1rem; align-items: flex-start;
+        display: flex !important;
+        flex-direction: row !important;
+        border: 1px solid var(--border-strong);
+        border-radius: 0 0 6px 6px;
+        overflow: hidden;
+        min-height: 500px;
     }
-    .editor-write {
-        flex: 1; display: flex; flex-direction: column; min-width: 0;
+    .editor-textarea {
+        flex: 1 !important;
+        min-height: 500px;
+        padding: 1rem !important;
+        font-family: 'Menlo', 'Consolas', 'Monaco', monospace !important;
+        font-size: 0.9rem !important;
+        line-height: 1.65 !important;
+        border: none !important;
+        border-right: 1px solid var(--border-strong) !important;
+        border-radius: 0 !important;
+        resize: none !important;
+        outline: none !important;
+        background: var(--editor-bg) !important;
+        color: var(--editor-text) !important;
+        box-shadow: none !important;
     }
-    .editor-write #content-input {
-        flex: 1; min-height: 480px; resize: vertical; font-family: monospace; font-size: 0.9rem;
-    }
+    /* Preview pane — always light (simulates how the post looks on the public site) */
     .editor-preview {
-        flex: 1; min-width: 0; border: 1px solid #e5e7eb; border-radius: 6px;
-        padding: 1rem 1.25rem; overflow-y: auto; max-height: 560px;
-        background: #fafafa;
+        flex: 1 !important;
+        min-height: 500px;
+        padding: 1.75rem 2rem !important;
+        overflow-y: auto;
+        background: #ffffff !important;
+        color: #1a1a1a !important;
+        border-left: 1px solid var(--border-strong);
     }
     .preview-label {
-        font-size: 0.7rem; font-weight: 700; color: #9ca3af;
-        text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.75rem;
+        font-size: 0.65rem;
+        font-weight: 700;
+        color: #9ca3af !important;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        margin-bottom: 1rem;
     }
-    #live-preview-output { font-size: 0.95rem; line-height: 1.7; }
-    #live-preview-output h1, #live-preview-output h2, #live-preview-output h3 { margin-top: 1rem; }
-    #live-preview-output code { background: #f3f4f6; padding: 0.1em 0.3em; border-radius: 3px; font-size: 0.85em; }
-    #live-preview-output pre { background: #f3f4f6; padding: 0.75rem 1rem; border-radius: 4px; overflow-x: auto; }
-    #live-preview-output blockquote { border-left: 3px solid #d1d5db; margin-left: 0; padding-left: 1rem; color: #6b7280; }
+    #live-preview-output {
+        font-family: Georgia, 'Times New Roman', serif;
+        font-size: 1rem;
+        line-height: 1.8;
+        color: #1a1a1a !important;
+        max-width: 62ch;
+    }
+    /* Force all preview text back to serif — prevents pre/code font bleeding */
+    #live-preview-output * { font-family: Georgia, 'Times New Roman', serif; box-sizing: border-box; }
+    #live-preview-output h1 {
+        font-size: 1.9rem !important; font-weight: 700; color: #111827 !important;
+        margin: 0 0 1rem !important; padding-bottom: 0.5rem;
+        border-bottom: 2px solid #e5e7eb;
+        font-family: system-ui, sans-serif !important;
+        line-height: 1.2;
+    }
+    #live-preview-output h2 {
+        font-size: 1.35rem !important; font-weight: 700; color: #1f2937 !important;
+        margin: 1.75rem 0 0.5rem !important;
+        font-family: system-ui, sans-serif !important;
+        line-height: 1.3;
+    }
+    #live-preview-output h3 {
+        font-size: 1.1rem !important; font-weight: 600; color: #374151 !important;
+        margin: 1.5rem 0 0.4rem !important;
+        font-family: system-ui, sans-serif !important;
+    }
+    #live-preview-output p  { margin: 0.75rem 0; color: #374151 !important; }
+    #live-preview-output a  { color: #6366f1 !important; text-decoration: underline; }
+    #live-preview-output strong { color: #111827 !important; font-weight: 700; }
+    #live-preview-output em { font-style: italic; }
+    #live-preview-output ul, #live-preview-output ol { padding-left: 1.5rem !important; margin: 0.75rem 0 !important; color: #374151 !important; }
+    #live-preview-output li { margin: 0.3rem 0 !important; }
+    /* Inline code */
+    #live-preview-output code {
+        background: #f3f4f6 !important;
+        color: #1f2937 !important;
+        padding: 0.15em 0.4em !important;
+        border-radius: 3px !important;
+        font-size: 0.85em !important;
+        font-family: 'Menlo', 'Consolas', monospace !important;
+        border: 1px solid #e5e7eb !important;
+    }
+    /* Code blocks — GitHub-style light */
+    #live-preview-output pre {
+        background: #f6f8fa !important;
+        border: 1px solid #d0d7de !important;
+        border-radius: 6px !important;
+        padding: 1rem 1.25rem !important;
+        overflow-x: auto;
+        margin: 1rem 0 !important;
+    }
+    #live-preview-output pre code {
+        background: none !important;
+        color: #24292e !important;
+        border: none !important;
+        padding: 0 !important;
+        font-size: 0.875rem !important;
+        font-family: 'Menlo', 'Consolas', monospace !important;
+    }
+    /* Blockquote */
+    #live-preview-output blockquote {
+        background: #f5f3ff !important;
+        border-left: 4px solid #6366f1 !important;
+        margin: 1rem 0 !important;
+        padding: 0.75rem 1rem !important;
+        border-radius: 0 4px 4px 0 !important;
+        color: #4b5563 !important;
+        font-style: italic;
+    }
+    #live-preview-output blockquote p { margin: 0 !important; color: inherit !important; }
+    #live-preview-output img { max-width: 100%; border-radius: 6px; margin: 0.5rem 0; }
+    #live-preview-output hr { border: none !important; border-top: 1px solid #e5e7eb !important; margin: 1.5rem 0; }
+
+    /* ── Save bar ── */
+    .save-bar {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        margin-top: 1rem;
+    }
+    .save-bar button[type=submit] { margin: 0; }
+    .save-hint { font-size: 0.75rem; color: var(--text-faint); }
+
+    /* ── Media uploads ── */
+    .media-upload {
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 0.65rem 1rem;
+        margin-top: 1.25rem;
+        background: var(--surface-2);
+    }
+    .media-upload summary { font-size: 0.85rem; font-weight: 600; color: var(--text-2); cursor: pointer; }
+    .upload-form { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; margin: 0.75rem 0 0.5rem; }
+    .upload-form input[type=file] { flex: 1; min-width: 200px; margin: 0 !important; }
+    .upload-form button { margin: 0; white-space: nowrap; }
 </style>
+{% endblock %}
+
+{% block content %}
+<section>
+    <form method="post">
+        <input type="hidden" name="original_slug" value="{{ post_data.original_slug }}">
+
+        <!-- Top bar -->
+        <div class="editor-topbar">
+            <h2>{{ 'New Post' if is_new else 'Edit Post' }}</h2>
+            <a href="{{ url_for('authoring.dashboard') }}" role="button" class="secondary">← Dashboard</a>
+            {% if not is_new %}
+                <a href="{{ url_for('authoring.preview_post', slug=post_data.slug or post_data.original_slug) }}" role="button" class="secondary" target="_blank">Preview ↗</a>
+            {% endif %}
+        </div>
+
+        <!-- Title -->
+        <div class="title-field">
+            <input id="title-input" name="title" type="text" value="{{ post_data.title }}" placeholder="Post title…" required>
+        </div>
+
+        <!-- Metadata row -->
+        <div class="meta-row">
+            <div class="meta-field grow">
+                <span class="meta-label">Slug</span>
+                <input id="slug-input" name="slug" type="text" value="{{ post_data.slug }}" placeholder="auto-from-title">
+                <small id="slug-preview"></small>
+            </div>
+            <div class="meta-field">
+                <span class="meta-label">Date</span>
+                <input name="date" type="date" value="{{ post_data.date }}">
+            </div>
+            <div class="meta-field">
+                <span class="meta-label">Status</span>
+                <select name="status">
+                    <option value="draft" {% if post_data.status == 'draft' %}selected{% endif %}>Draft</option>
+                    <option value="published" {% if post_data.status == 'published' %}selected{% endif %}>Published</option>
+                </select>
+            </div>
+            <div class="meta-field meta-check">
+                <label><input name="featured" type="checkbox" {% if post_data.featured %}checked{% endif %}> Featured</label>
+            </div>
+        </div>
+
+        <!-- Extra metadata (collapsible) -->
+        <details class="extra-meta">
+            <summary>Description, excerpt &amp; hero image…</summary>
+            <div class="extra-meta-grid">
+                <div class="full">
+                    <label>Description</label>
+                    <textarea name="description" rows="2">{{ post_data.description }}</textarea>
+                </div>
+                <div class="full">
+                    <label>Excerpt</label>
+                    <textarea name="excerpt" rows="2">{{ post_data.excerpt }}</textarea>
+                </div>
+                <div class="full">
+                    <label>Hero image URL</label>
+                    <input name="hero_image" type="text" value="{{ post_data.hero_image }}" placeholder="/static/uploads/hero.jpg">
+                </div>
+            </div>
+        </details>
+
+        <!-- Markdown toolbar -->
+        <div class="md-toolbar" id="md-toolbar" role="toolbar" aria-label="Markdown formatting">
+            <div class="toolbar-group">
+                <button type="button" data-wrap="**" title="Bold (Ctrl+B)"><strong>B</strong></button>
+                <button type="button" data-wrap="_" title="Italic (Ctrl+I)"><em>I</em></button>
+            </div>
+            <div class="toolbar-sep"></div>
+            <div class="toolbar-group">
+                <button type="button" data-prefix="## " title="Heading 2">H2</button>
+                <button type="button" data-prefix="### " title="Heading 3">H3</button>
+            </div>
+            <div class="toolbar-sep"></div>
+            <div class="toolbar-group">
+                <button type="button" data-wrap="`" title="Inline code">code</button>
+                <button type="button" data-prefix="```&#10;" data-suffix="&#10;```" title="Code block">{ }</button>
+                <button type="button" data-prefix="> " title="Blockquote">quote</button>
+                <button type="button" data-prefix="- " title="Bullet list">list</button>
+            </div>
+            <div class="toolbar-sep"></div>
+            <div class="toolbar-group">
+                <button type="button" data-snippet="[link text](url)" title="Insert link">link</button>
+                <button type="button" data-snippet="![alt text](url)" title="Insert image">img</button>
+            </div>
+        </div>
+
+        <!-- Split editor -->
+        <div class="editor-split">
+            <textarea id="content-input" name="content" class="editor-textarea" required spellcheck="false">{{ post_data.content }}</textarea>
+            <div class="editor-preview">
+                <div class="preview-label">Live preview</div>
+                <div id="live-preview-output"></div>
+            </div>
+        </div>
+
+        <!-- Save -->
+        <div class="save-bar">
+            <button type="submit">Save post</button>
+            <span class="save-hint">Ctrl+S</span>
+        </div>
+    </form>
+
+    <!-- Media upload (separate form — needs multipart enctype) -->
+    <details class="media-upload">
+        <summary>Media uploads</summary>
+        <form method="post" action="{{ url_for('authoring.upload_media') }}" enctype="multipart/form-data" class="upload-form">
+            <input type="hidden" name="next" value="{{ request.full_path }}">
+            <input name="media_file" type="file" required>
+            <button type="submit">Upload</button>
+        </form>
+        <div id="media-gallery" class="media-gallery">
+            <p style="color:var(--text-muted); font-size:0.85rem;">Loading…</p>
+        </div>
+    </details>
+</section>
 {% endblock %}
 
 {% block extra_scripts %}
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script>
 (function () {
-    const titleInput = document.getElementById('title-input');
-    const slugInput  = document.getElementById('slug-input');
+    // Slug auto-generation
+    const titleInput  = document.getElementById('title-input');
+    const slugInput   = document.getElementById('slug-input');
     const slugPreview = document.getElementById('slug-preview');
 
-    // Mirrors the Python slugify() in views.py exactly (ASCII scope).
     function slugify(value) {
         let s = value.trim().toLowerCase();
         s = s.replace(/[^a-z0-9\- ]/g, ' ');
         return s.split(/\s+/).filter(Boolean).join('-');
     }
 
-    // Don't auto-fill if the slug is already set (edit mode).
     let manualSlug = slugInput.value !== '';
 
     function refreshPreview() {
@@ -147,45 +418,70 @@
     }
 
     titleInput.addEventListener('input', function () {
-        if (!manualSlug) {
-            slugInput.value = slugify(this.value);
-        }
+        if (!manualSlug) slugInput.value = slugify(this.value);
         refreshPreview();
     });
-
     slugInput.addEventListener('input', function () {
         manualSlug = this.value !== '';
         refreshPreview();
     });
-
     refreshPreview();
 }());
 
-// Live markdown preview
 (function () {
+    // Live preview
     const textarea = document.getElementById('content-input');
     const output   = document.getElementById('live-preview-output');
     if (!textarea || !output || typeof marked === 'undefined') return;
-
-    function renderPreview() {
-        output.innerHTML = marked.parse(textarea.value || '');
-    }
-
-    textarea.addEventListener('input', renderPreview);
-    renderPreview();
+    function render() { output.innerHTML = marked.parse(textarea.value || ''); }
+    textarea.addEventListener('input', render);
+    render();
 }());
 
-// Media gallery — loads uploaded files via JSON, click to insert URL into textarea
 (function () {
-    const gallery = document.getElementById('media-gallery');
+    // Toolbar
+    const textarea = document.getElementById('content-input');
+    document.getElementById('md-toolbar').addEventListener('click', function (e) {
+        const btn = e.target.closest('button[data-wrap], button[data-prefix], button[data-snippet]');
+        if (!btn) return;
+        e.preventDefault();
+        const start = textarea.selectionStart;
+        const end   = textarea.selectionEnd;
+        const sel   = textarea.value.slice(start, end);
+        let replacement = '';
+        if (btn.dataset.snippet) {
+            replacement = btn.dataset.snippet;
+        } else if (btn.dataset.wrap) {
+            const w = btn.dataset.wrap;
+            replacement = sel ? w + sel + w : w + w;
+        } else if (btn.dataset.prefix) {
+            const prefix = btn.dataset.prefix;
+            const suffix = btn.dataset.suffix || '';
+            replacement = sel ? prefix + sel + suffix : prefix + suffix;
+        }
+        textarea.setRangeText(replacement, start, end, 'end');
+        textarea.focus();
+    });
+
+    // Ctrl+S — submit form
+    document.addEventListener('keydown', function (e) {
+        if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+            e.preventDefault();
+            document.querySelector('form button[type=submit]').click();
+        }
+    });
+}());
+
+(function () {
+    // Media gallery
+    const gallery  = document.getElementById('media-gallery');
     const textarea = document.getElementById('content-input');
     if (!gallery) return;
-
     fetch('{{ url_for("authoring.list_uploads") }}')
         .then(function (r) { return r.json(); })
         .then(function (files) {
             if (files.length === 0) {
-                gallery.innerHTML = '<p style="color:#6b7280;font-size:0.85rem;">No uploads yet.</p>';
+                gallery.innerHTML = '<p style="color:var(--text-muted);font-size:0.85rem;">No uploads yet.</p>';
                 return;
             }
             gallery.innerHTML = '';
@@ -202,12 +498,10 @@
                     item.textContent = f.filename;
                 }
                 item.addEventListener('click', function () {
-                    const insertion = f.is_image
-                        ? '![](' + f.url + ')'
-                        : f.url;
+                    const ins   = f.is_image ? '![](' + f.url + ')' : f.url;
                     const start = textarea.selectionStart;
                     const end   = textarea.selectionEnd;
-                    textarea.setRangeText(insertion, start, end, 'end');
+                    textarea.setRangeText(ins, start, end, 'end');
                     textarea.focus();
                 });
                 gallery.appendChild(item);
@@ -216,35 +510,6 @@
         .catch(function () {
             gallery.innerHTML = '<p style="color:#b91c1c;font-size:0.85rem;">Could not load uploads.</p>';
         });
-}());
-
-// Markdown toolbar
-(function () {
-    const textarea = document.getElementById('content-input');
-    document.getElementById('md-toolbar').addEventListener('click', function (e) {
-        const btn = e.target.closest('button[data-wrap], button[data-prefix], button[data-snippet]');
-        if (!btn) return;
-        e.preventDefault();
-
-        const start = textarea.selectionStart;
-        const end   = textarea.selectionEnd;
-        const sel   = textarea.value.slice(start, end);
-        let replacement = '';
-
-        if (btn.dataset.snippet) {
-            replacement = btn.dataset.snippet;
-        } else if (btn.dataset.wrap) {
-            const w = btn.dataset.wrap;
-            replacement = sel ? w + sel + w : w + w;
-        } else if (btn.dataset.prefix) {
-            const prefix = btn.dataset.prefix;
-            const suffix = btn.dataset.suffix || '';
-            replacement = sel ? prefix + sel + suffix : prefix + suffix;
-        }
-
-        textarea.setRangeText(replacement, start, end, 'end');
-        textarea.focus();
-    });
 }());
 </script>
 {% endblock %}

--- a/authoring_app/templates/authoring/edit.html
+++ b/authoring_app/templates/authoring/edit.html
@@ -62,19 +62,27 @@
         <label>
             <input name="featured" type="checkbox" {% if post_data.featured %}checked{% endif %}> Featured post
         </label>
-        <label>Content (Markdown)</label>
-        <div class="md-toolbar" id="md-toolbar">
-            <button type="button" data-wrap="**" title="Bold">B</button>
-            <button type="button" data-wrap="_" title="Italic">I</button>
-            <button type="button" data-prefix="## " title="Heading">H2</button>
-            <button type="button" data-prefix="### " title="Heading 3">H3</button>
-            <button type="button" data-wrap="`" title="Inline code">Code</button>
-            <button type="button" data-prefix="```\n" data-suffix="\n```" title="Code block">```</button>
-            <button type="button" data-prefix="> " title="Blockquote">Quote</button>
-            <button type="button" data-snippet="[link text](url)" title="Link">Link</button>
-            <button type="button" data-snippet="![alt text](url)" title="Image">Img</button>
+        <div class="editor-split">
+            <div class="editor-write">
+                <label>Content (Markdown)</label>
+                <div class="md-toolbar" id="md-toolbar">
+                    <button type="button" data-wrap="**" title="Bold">B</button>
+                    <button type="button" data-wrap="_" title="Italic">I</button>
+                    <button type="button" data-prefix="## " title="Heading">H2</button>
+                    <button type="button" data-prefix="### " title="Heading 3">H3</button>
+                    <button type="button" data-wrap="`" title="Inline code">Code</button>
+                    <button type="button" data-prefix="```\n" data-suffix="\n```" title="Code block">```</button>
+                    <button type="button" data-prefix="> " title="Blockquote">Quote</button>
+                    <button type="button" data-snippet="[link text](url)" title="Link">Link</button>
+                    <button type="button" data-snippet="![alt text](url)" title="Image">Img</button>
+                </div>
+                <textarea id="content-input" name="content" required>{{ post_data.content }}</textarea>
+            </div>
+            <div class="editor-preview">
+                <p class="preview-label">Live preview</p>
+                <div id="live-preview-output"></div>
+            </div>
         </div>
-        <textarea id="content-input" name="content" required>{{ post_data.content }}</textarea>
         <footer class="actions">
             <button type="submit">Save post</button>
             <a class="secondary" role="button" href="{{ url_for('authoring.dashboard') }}">Cancel</a>
@@ -86,7 +94,37 @@
 </section>
 {% endblock %}
 
+{% block extra_head %}
+<style>
+    body { max-width: 1400px !important; }
+    .editor-split {
+        display: flex; gap: 1rem; align-items: flex-start;
+    }
+    .editor-write {
+        flex: 1; display: flex; flex-direction: column; min-width: 0;
+    }
+    .editor-write #content-input {
+        flex: 1; min-height: 480px; resize: vertical; font-family: monospace; font-size: 0.9rem;
+    }
+    .editor-preview {
+        flex: 1; min-width: 0; border: 1px solid #e5e7eb; border-radius: 6px;
+        padding: 1rem 1.25rem; overflow-y: auto; max-height: 560px;
+        background: #fafafa;
+    }
+    .preview-label {
+        font-size: 0.7rem; font-weight: 700; color: #9ca3af;
+        text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.75rem;
+    }
+    #live-preview-output { font-size: 0.95rem; line-height: 1.7; }
+    #live-preview-output h1, #live-preview-output h2, #live-preview-output h3 { margin-top: 1rem; }
+    #live-preview-output code { background: #f3f4f6; padding: 0.1em 0.3em; border-radius: 3px; font-size: 0.85em; }
+    #live-preview-output pre { background: #f3f4f6; padding: 0.75rem 1rem; border-radius: 4px; overflow-x: auto; }
+    #live-preview-output blockquote { border-left: 3px solid #d1d5db; margin-left: 0; padding-left: 1rem; color: #6b7280; }
+</style>
+{% endblock %}
+
 {% block extra_scripts %}
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script>
 (function () {
     const titleInput = document.getElementById('title-input');
@@ -121,6 +159,20 @@
     });
 
     refreshPreview();
+}());
+
+// Live markdown preview
+(function () {
+    const textarea = document.getElementById('content-input');
+    const output   = document.getElementById('live-preview-output');
+    if (!textarea || !output || typeof marked === 'undefined') return;
+
+    function renderPreview() {
+        output.innerHTML = marked.parse(textarea.value || '');
+    }
+
+    textarea.addEventListener('input', renderPreview);
+    renderPreview();
 }());
 
 // Media gallery — loads uploaded files via JSON, click to insert URL into textarea

--- a/authoring_app/templates/authoring/edit.html
+++ b/authoring_app/templates/authoring/edit.html
@@ -57,10 +57,19 @@
         <label>
             <input name="featured" type="checkbox" {% if post_data.featured %}checked{% endif %}> Featured post
         </label>
-        <label>
-            Content (Markdown)
-            <textarea name="content" required>{{ post_data.content }}</textarea>
-        </label>
+        <label>Content (Markdown)</label>
+        <div class="md-toolbar" id="md-toolbar">
+            <button type="button" data-wrap="**" title="Bold">B</button>
+            <button type="button" data-wrap="_" title="Italic">I</button>
+            <button type="button" data-prefix="## " title="Heading">H2</button>
+            <button type="button" data-prefix="### " title="Heading 3">H3</button>
+            <button type="button" data-wrap="`" title="Inline code">Code</button>
+            <button type="button" data-prefix="```\n" data-suffix="\n```" title="Code block">```</button>
+            <button type="button" data-prefix="> " title="Blockquote">Quote</button>
+            <button type="button" data-snippet="[link text](url)" title="Link">Link</button>
+            <button type="button" data-snippet="![alt text](url)" title="Image">Img</button>
+        </div>
+        <textarea id="content-input" name="content" required>{{ post_data.content }}</textarea>
         <footer class="actions">
             <button type="submit">Save post</button>
             <a class="secondary" role="button" href="{{ url_for('authoring.dashboard') }}">Cancel</a>
@@ -107,6 +116,35 @@
     });
 
     refreshPreview();
+}());
+
+// Markdown toolbar
+(function () {
+    const textarea = document.getElementById('content-input');
+    document.getElementById('md-toolbar').addEventListener('click', function (e) {
+        const btn = e.target.closest('button[data-wrap], button[data-prefix], button[data-snippet]');
+        if (!btn) return;
+        e.preventDefault();
+
+        const start = textarea.selectionStart;
+        const end   = textarea.selectionEnd;
+        const sel   = textarea.value.slice(start, end);
+        let replacement = '';
+
+        if (btn.dataset.snippet) {
+            replacement = btn.dataset.snippet;
+        } else if (btn.dataset.wrap) {
+            const w = btn.dataset.wrap;
+            replacement = sel ? w + sel + w : w + w;
+        } else if (btn.dataset.prefix) {
+            const prefix = btn.dataset.prefix;
+            const suffix = btn.dataset.suffix || '';
+            replacement = sel ? prefix + sel + suffix : prefix + suffix;
+        }
+
+        textarea.setRangeText(replacement, start, end, 'end');
+        textarea.focus();
+    });
 }());
 </script>
 {% endblock %}

--- a/authoring_app/templates/authoring/edit.html
+++ b/authoring_app/templates/authoring/edit.html
@@ -31,11 +31,12 @@
         <input type="hidden" name="original_slug" value="{{ post_data.original_slug }}">
         <label>
             Title
-            <input name="title" type="text" value="{{ post_data.title }}" required>
+            <input id="title-input" name="title" type="text" value="{{ post_data.title }}" required>
         </label>
         <label>
             Slug
-            <input name="slug" type="text" value="{{ post_data.slug }}" placeholder="auto-from-title">
+            <input id="slug-input" name="slug" type="text" value="{{ post_data.slug }}" placeholder="auto-from-title">
+            <small id="slug-preview" style="color: #6b7280; font-family: monospace;"></small>
         </label>
         <label>
             Date
@@ -69,4 +70,43 @@
         </footer>
     </form>
 </section>
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+(function () {
+    const titleInput = document.getElementById('title-input');
+    const slugInput  = document.getElementById('slug-input');
+    const slugPreview = document.getElementById('slug-preview');
+
+    // Mirrors the Python slugify() in views.py exactly (ASCII scope).
+    function slugify(value) {
+        let s = value.trim().toLowerCase();
+        s = s.replace(/[^a-z0-9\- ]/g, ' ');
+        return s.split(/\s+/).filter(Boolean).join('-');
+    }
+
+    // Don't auto-fill if the slug is already set (edit mode).
+    let manualSlug = slugInput.value !== '';
+
+    function refreshPreview() {
+        const computed = slugify(slugInput.value || slugify(titleInput.value));
+        slugPreview.textContent = computed ? '/blog/' + computed + '/' : '';
+    }
+
+    titleInput.addEventListener('input', function () {
+        if (!manualSlug) {
+            slugInput.value = slugify(this.value);
+        }
+        refreshPreview();
+    });
+
+    slugInput.addEventListener('input', function () {
+        manualSlug = this.value !== '';
+        refreshPreview();
+    });
+
+    refreshPreview();
+}());
+</script>
 {% endblock %}

--- a/authoring_app/templates/authoring/edit.html
+++ b/authoring_app/templates/authoring/edit.html
@@ -5,27 +5,25 @@
         <h2>{{ 'Create Post' if is_new else 'Edit Post' }}</h2>
     </header>
 
-    <section class="media-upload">
-        <h3>Upload images, video, or audio</h3>
-        <p>
-            Use this uploader to add media files to
-            <code>{{ media_url_prefix }}</code>. After the upload completes, copy
-            the flashed URL into the Hero image field or embed it in your Markdown
-            using standard Markdown image syntax or HTML media tags.
-        </p>
+    <details class="media-upload">
+        <summary>Media uploads</summary>
         <form
             method="post"
             action="{{ url_for('authoring.upload_media') }}"
             enctype="multipart/form-data"
+            style="display:flex; gap:0.5rem; align-items:flex-end; flex-wrap:wrap; margin-bottom:0.75rem;"
         >
             <input type="hidden" name="next" value="{{ request.full_path }}">
-            <label>
+            <label style="margin:0; flex:1; min-width:200px;">
                 Choose file
                 <input name="media_file" type="file" required>
             </label>
-            <button type="submit">Upload media</button>
+            <button type="submit" style="margin:0;">Upload</button>
         </form>
-    </section>
+        <div id="media-gallery" class="media-gallery">
+            <p style="color:#6b7280; font-size:0.85rem;">Loading uploads…</p>
+        </div>
+    </details>
 
     <form method="post">
         <input type="hidden" name="original_slug" value="{{ post_data.original_slug }}">
@@ -123,6 +121,49 @@
     });
 
     refreshPreview();
+}());
+
+// Media gallery — loads uploaded files via JSON, click to insert URL into textarea
+(function () {
+    const gallery = document.getElementById('media-gallery');
+    const textarea = document.getElementById('content-input');
+    if (!gallery) return;
+
+    fetch('{{ url_for("authoring.list_uploads") }}')
+        .then(function (r) { return r.json(); })
+        .then(function (files) {
+            if (files.length === 0) {
+                gallery.innerHTML = '<p style="color:#6b7280;font-size:0.85rem;">No uploads yet.</p>';
+                return;
+            }
+            gallery.innerHTML = '';
+            files.forEach(function (f) {
+                const item = document.createElement('div');
+                item.className = 'media-item';
+                item.title = 'Click to insert: ' + f.url;
+                if (f.is_image) {
+                    const img = document.createElement('img');
+                    img.src = f.url;
+                    img.alt = f.filename;
+                    item.appendChild(img);
+                } else {
+                    item.textContent = f.filename;
+                }
+                item.addEventListener('click', function () {
+                    const insertion = f.is_image
+                        ? '![](' + f.url + ')'
+                        : f.url;
+                    const start = textarea.selectionStart;
+                    const end   = textarea.selectionEnd;
+                    textarea.setRangeText(insertion, start, end, 'end');
+                    textarea.focus();
+                });
+                gallery.appendChild(item);
+            });
+        })
+        .catch(function () {
+            gallery.innerHTML = '<p style="color:#b91c1c;font-size:0.85rem;">Could not load uploads.</p>';
+        });
 }());
 
 // Markdown toolbar

--- a/authoring_app/templates/authoring/edit.html
+++ b/authoring_app/templates/authoring/edit.html
@@ -55,6 +55,13 @@
             <input name="hero_image" type="text" value="{{ post_data.hero_image }}" placeholder="/static/uploads/hero.jpg">
         </label>
         <label>
+            Status
+            <select name="status">
+                <option value="draft" {% if post_data.status == 'draft' %}selected{% endif %}>Draft</option>
+                <option value="published" {% if post_data.status == 'published' %}selected{% endif %}>Published</option>
+            </select>
+        </label>
+        <label>
             <input name="featured" type="checkbox" {% if post_data.featured %}checked{% endif %}> Featured post
         </label>
         <label>Content (Markdown)</label>

--- a/authoring_app/templates/authoring/index.html
+++ b/authoring_app/templates/authoring/index.html
@@ -1,16 +1,17 @@
 {% extends 'authoring/base.html' %}
 {% block content %}
 <section class="post-list">
-    <header class="actions">
+    <header class="actions" style="margin-bottom: 1rem;">
         <a role="button" class="contrast" href="{{ url_for('authoring.edit_post') }}">Create new post</a>
+        <input id="post-search" type="search" placeholder="Filter posts…" style="max-width: 280px; margin: 0;">
     </header>
 
     {% if posts %}
-        <table>
+        <table id="post-table">
             <thead>
                 <tr>
                     <th>Title</th>
-                    <th>Slug</th>
+                    <th>Status</th>
                     <th>Date</th>
                     <th>Updated</th>
                     <th></th>
@@ -20,7 +21,10 @@
                 {% for post in posts %}
                     <tr>
                         <td>{{ post.title }}</td>
-                        <td>{{ post.slug }}</td>
+                        <td>
+                            {% set s = post.get('status', 'draft') %}
+                            <span class="status-badge status-{{ s }}">{{ s }}</span>
+                        </td>
                         <td>{{ post.date or '—' }}</td>
                         <td>{{ post.updated_at.strftime('%Y-%m-%d %H:%M') if post.updated_at else '—' }}</td>
                         <td class="actions">
@@ -34,8 +38,32 @@
                 {% endfor %}
             </tbody>
         </table>
+        <p id="no-results" style="display:none;">No posts match your filter.</p>
     {% else %}
         <p>No posts found yet. Create your first article.</p>
     {% endif %}
 </section>
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+(function () {
+    const search = document.getElementById('post-search');
+    if (!search) return;
+    const rows = document.querySelectorAll('#post-table tbody tr');
+    const noResults = document.getElementById('no-results');
+
+    search.addEventListener('input', function () {
+        const term = this.value.toLowerCase();
+        let visible = 0;
+        rows.forEach(function (row) {
+            const text = row.textContent.toLowerCase();
+            const show = text.includes(term);
+            row.style.display = show ? '' : 'none';
+            if (show) visible++;
+        });
+        noResults.style.display = visible === 0 ? '' : 'none';
+    });
+}());
+</script>
 {% endblock %}

--- a/authoring_app/views.py
+++ b/authoring_app/views.py
@@ -9,6 +9,7 @@ from flask import (
     Blueprint,
     current_app,
     flash,
+    jsonify,
     redirect,
     render_template,
     request,
@@ -307,6 +308,23 @@ def preview_post(slug: str) -> str:
         hero_image_url=hero_image_url,
         site_name=current_app.config.get('SITE_NAME', 'Toucan.ee'),
     )
+
+
+@bp.route('/uploads/list')
+def list_uploads():
+    image_exts = {'png', 'jpg', 'jpeg', 'gif', 'webp', 'svg'}
+    media_dir = get_media_dir()
+    files = []
+    if media_dir.exists():
+        for path in sorted(media_dir.iterdir()):
+            ext = path.suffix.lower().lstrip('.')
+            if ext in allowed_media_extensions():
+                files.append({
+                    'filename': path.name,
+                    'url': build_media_url(path.name),
+                    'is_image': ext in image_exts,
+                })
+    return jsonify(files)
 
 
 @bp.route('/posts/<slug>/delete', methods=['POST'])

--- a/authoring_app/views.py
+++ b/authoring_app/views.py
@@ -144,6 +144,7 @@ def edit_post(slug: Optional[str] = None) -> str:
         hero_image, _ = normalize_media_path(hero_image_input)
         content = form.get('content', '').strip()
         featured = form.get('featured') == 'on'
+        status = form.get('status', 'draft')
         raw_date = form.get('date', '').strip()
         date_value = raw_date or datetime.now().date().isoformat()
 
@@ -183,6 +184,7 @@ def edit_post(slug: Optional[str] = None) -> str:
             'excerpt': excerpt,
             'hero_image': hero_image or None,
             'featured': featured,
+            'status': status,
         }
 
         save_post(
@@ -203,6 +205,7 @@ def edit_post(slug: Optional[str] = None) -> str:
             'excerpt': metadata.get('excerpt', ''),
             'hero_image': metadata.get('hero_image') or '',
             'featured': metadata.get('featured', False),
+            'status': metadata.get('status', 'draft'),
             'date': metadata.get('date', ''),
             'content': post.content,
             'original_slug': slug,
@@ -215,6 +218,7 @@ def edit_post(slug: Optional[str] = None) -> str:
             'excerpt': '',
             'hero_image': '',
             'featured': False,
+            'status': 'draft',
             'date': datetime.now().date().isoformat(),
             'content': '',
             'original_slug': '',


### PR DESCRIPTION
## Summary

Closes #130. Six focused improvements to the authoring tool writing experience:

- **Real-time slug preview** — as you type the title, the slug and URL path preview updates live below the slug field
- **Markdown toolbar** — B, I, H2, H3, Code, Code block, Quote, Link, Image buttons wrap selected text or insert at cursor
- **Draft/published status** — new `status` field saved to front matter; defaults to `draft`
- **Dashboard search + status badge** — filter posts by any text client-side; colour-coded draft/published badges in the post table
- **Media gallery** — uploaded images shown as clickable thumbnails; click to insert `![](url)` into the editor at cursor position; new `/authoring/uploads/list` JSON endpoint
- **Live split-pane preview** — editor and rendered markdown side-by-side using marked.js; preview updates on every keystroke

## Test plan

- [x] `make test` passes (18 tests)
- [x] `make authoring` starts the app on :5001
- [ ] Create a new post — slug auto-fills from title
- [ ] Toolbar buttons wrap selected text correctly
- [ ] Status dropdown saves `status:` to the markdown front matter
- [ ] Dashboard shows status badges; search input filters rows
- [ ] Upload an image — it appears in the gallery; click inserts markdown into editor
- [ ] Live preview renders markdown as you type