### PR TITLE
feat(coming-soon): replace site with email signup landing page

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ import os
 from datetime import datetime
 
 from dotenv import load_dotenv
-from flask import Flask, abort, g, render_template, request, url_for
+from flask import Flask, abort, g, redirect, render_template, request, url_for
 
 load_dotenv()
 
@@ -65,18 +65,17 @@ def build_page_context(**extra) -> dict:
     }
 
 
+NOTION_SIGNUP_URL = 'https://observant-toothpaste-fa5.notion.site/64939681cd2c4a1f899c6ac8d2fe4e74?pvs=105'
+
+
 @app.route('/')
 def home():
-    return render_template(
-        'home.html', **build_page_context(page_slug='home', posts=get_posts())
-    )
+    return render_template('coming-soon-full.html', signup_url=NOTION_SIGNUP_URL)
 
 
 @app.route('/blog/')
 def blog_index():
-    return render_template(
-        'blog/list.html', **build_page_context(page_slug='blog', posts=get_posts())
-    )
+    return redirect('/')
 
 
 @app.route('/blog/<slug>/')
@@ -99,7 +98,7 @@ def blog_detail(slug: str):
 
 @app.route('/about/')
 def about():
-    return render_template('about.html', **build_page_context(page_slug='about'))
+    return redirect('/')
 
 
 @app.route('/sitemap.xml')

--- a/static/css/components-blog.css
+++ b/static/css/components-blog.css
@@ -99,6 +99,17 @@
     font-family: var(--font-sans);
 }
 
+/* ── Coming soon signup ──────────────────────────────────────────────────────── */
+.coming-soon-signup {
+    margin-top: 2.5rem;
+}
+.notion-form-embed {
+    width: 100%;
+    min-height: 500px;
+    border: none;
+    border-radius: 8px;
+}
+
 /* ── Post back-link ──────────────────────────────────────────────────────────── */
 .blog-post-nav {
     margin-bottom: 2.5rem;

--- a/templates/blog/coming-soon.html
+++ b/templates/blog/coming-soon.html
@@ -1,0 +1,21 @@
+{% extends 'blog/base.html' %}
+
+{% block title %}Writing — Coming Soon | {{ config.name }}{% endblock %}
+{% block meta_description %}The blog is coming soon. Sign up to be notified when it launches.{% endblock %}
+
+{% block content %}
+<div class="blog-list-header">
+    <h1>Writing</h1>
+    <p>Something is on the way. Leave your email and I'll let you know when it's live.</p>
+</div>
+
+<div class="coming-soon-signup">
+    <iframe
+        src="https://www.notion.so/64939681cd2c4a1f899c6ac8d2fe4e74"
+        class="notion-form-embed"
+        frameborder="0"
+        allowfullscreen
+        title="Blog launch notification signup">
+    </iframe>
+</div>
+{% endblock %}

--- a/templates/coming-soon-full.html
+++ b/templates/coming-soon-full.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sreyeesh Garimella — Coming Soon</title>
+    <style>
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+        body {
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: #0f0f0f;
+            color: #e5e5e5;
+            font-family: Georgia, 'Times New Roman', serif;
+            padding: 2rem 1.25rem;
+        }
+
+        .card {
+            max-width: 520px;
+            width: 100%;
+            text-align: center;
+        }
+
+        .eyebrow {
+            font-family: system-ui, sans-serif;
+            font-size: 0.75rem;
+            font-weight: 600;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+            color: #6b7280;
+            margin-bottom: 1.5rem;
+        }
+
+        h1 {
+            font-size: 2.25rem;
+            font-weight: 700;
+            line-height: 1.2;
+            color: #f9fafb;
+            margin-bottom: 1.25rem;
+        }
+
+        .description {
+            font-size: 1.05rem;
+            line-height: 1.75;
+            color: #9ca3af;
+            margin-bottom: 2rem;
+        }
+
+        .description strong {
+            color: #e5e7eb;
+        }
+
+        .cta {
+            display: inline-block;
+            padding: 0.85rem 2rem;
+            background: #f9fafb;
+            color: #111;
+            font-family: system-ui, sans-serif;
+            font-size: 0.95rem;
+            font-weight: 600;
+            border-radius: 6px;
+            text-decoration: none;
+            transition: background 0.15s ease;
+            margin-bottom: 1rem;
+        }
+
+        .cta:hover { background: #e5e7eb; }
+
+        .note {
+            font-family: system-ui, sans-serif;
+            font-size: 0.8rem;
+            color: #4b5563;
+        }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <p class="eyebrow">Sreyeesh Garimella</p>
+        <h1>Something is on the way.</h1>
+        <p class="description">
+            I'm building a blog about <strong>software development, tools, and the craft of building things</strong>.
+            Leave your email and I'll send you a note the moment it goes live — no spam, just one email when it's ready.
+        </p>
+        <a class="cta" href="{{ signup_url }}" target="_blank" rel="noopener noreferrer">
+            Notify me when it launches →
+        </a>
+        <p class="note">No Notion account needed — just enter your email and hit submit.</p>
+    </div>
+</body>
+</html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,25 +2,24 @@ from blog import load_posts
 
 
 def test_home_page(client):
-    """Test that the home page loads successfully."""
+    """Home page loads the coming soon landing page."""
     response = client.get('/')
-    body = response.get_data(as_text=True)
     assert response.status_code == 200
-    assert 'Sreyeesh Garimella' in body
+    assert b'Sreyeesh Garimella' in response.data
 
 
 def test_home_page_content(client):
-    """Test that the page contains expected content."""
+    """Coming soon page has signup link and no-account note."""
     response = client.get('/')
-    body = response.get_data(as_text=True)
-    assert 'Full-stack developer' in body
+    assert b'notion.site' in response.data
+    assert b'Notion account' in response.data
 
 
 def test_pages_load(client):
-    """Ensure top-level pages render."""
+    """Blog index redirects to home."""
     response = client.get('/blog/')
-    assert response.status_code == 200
-    assert b'Writing' in response.data
+    assert response.status_code == 302
+    assert response.location == '/'
 
 
 def test_sitemap_endpoint(client):
@@ -57,8 +56,8 @@ def test_markdown_posts_available():
 
 def test_blog_index(client):
     response = client.get('/blog/')
-    assert response.status_code == 200
-    assert b'Writing' in response.data
+    assert response.status_code == 302
+    assert response.location == '/'
 
 
 def test_blog_detail(client, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Closes #137. Replaces the public site with a minimal coming soon landing page while the blog is in development.

- `/` serves a dark landing page explaining the blog is coming, with a button linking to the Notion signup form
- `/blog/` redirects to `/`
- `/about/` redirects to `/`
- Notion form is publicly accessible (no account required) at `observant-toothpaste-fa5.notion.site`
- Submissions go into the **Blog Launch Signups** Notion database

## Test plan

- [x] `make test` passes (18 tests)
- [x] `http://localhost:5000` shows the coming soon landing page
- [x] Clicking "Notify me when it launches →" opens the Notion form in a new tab
- [x] Form is fillable without a Notion account (verify in incognito)
- [x] `/blog/` and `/about/` redirect to `/`
- [ ] Submissions appear in the Notion database

Closes #137