### PR TITLE
fix(freeze): follow redirects when generating static routes

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -40,7 +40,7 @@ def build_static_site() -> None:
                 ('/about/', BUILD_DIR / 'about' / 'index.html'),
             ]
             for route, destination in static_routes:
-                response = client.get(route)
+                response = client.get(route, follow_redirects=True)
                 if response.status_code != 200:
                     raise RuntimeError(f'Failed to render {route}.')
                 write_file(destination, response.data.decode('utf-8'))


### PR DESCRIPTION
## Summary

`freeze.py` raised a `RuntimeError` on `/blog/` and `/about/` because they now return 302 redirects. Added `follow_redirects=True` to the test client calls so the freezer follows the redirect and writes the final HTML.

## Root cause

PR #139 changed `/blog/` and `/about/` to redirect to `/`. The static site generator checked for `status_code == 200` and failed on the 302.