### PR TITLE
feat: coming-soon page, about page, Jinja2 refactor, and CI fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,19 @@
+---
+name: Bug
+about: Something isn't working as expected
+labels: fix
+---
+
+## What's happening
+Clear description of the bug.
+
+## Steps to reproduce
+1. 
+2. 
+3. 
+
+## Expected behaviour
+What should happen.
+
+## Actual behaviour
+What actually happens.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,16 @@
+---
+name: Feature
+about: New functionality or enhancement
+labels: feat
+---
+
+## Goal
+What we're trying to achieve and why.
+
+## Acceptance criteria
+- [ ] 
+- [ ] 
+- [ ] 
+
+## Notes
+Any constraints, design decisions, or context.

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,13 @@ dist/
 *.swp
 *.swo
 
+# AI tooling
+.agents/
+.claude/
+.junie/
+.impeccable.md
+skills-lock.json
+
 # OS
 .DS_Store
 Thumbs.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,64 +4,76 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Commands
 
-**Primary interface via Makefile:**
+All commands run inside Docker via the Makefile — never use local Python or venv directly.
+
 - `make install` — Build all Docker images
-- `make run` — Run dev container (Flask on :5000 with hot reload)
+- `make run` — Start dev container with hot reload (http://localhost:5002)
 - `make test` — Run pytest suite in Docker
 - `make freeze` — Generate static build into `build/`
 - `make docker-build` / `make docker-up` — Build/run production container (:3000)
 - `make authoring` — Start authoring CMS container (:5001)
-- `make deploy` — Freeze and deploy via GitHub Pages (`deploy-gh-pages.sh`)
+- `make deploy` — Freeze and deploy via GitHub Pages
 - `make clean` — Remove `build/` and `.pytest_cache`
 
-**Without Docker:**
-- `python app.py` — Dev server (Flask :5000)
-- `pytest` — Run tests (with coverage)
-- `pytest tests/test_foo.py::test_bar` — Run single test
-- `flake8 .` — Lint (max 88 chars, excludes .git/__pycache__/.venv)
-- `python freeze.py` — Build static site
+To run a single test: `docker compose run --rm tests pytest tests/test_app.py::test_name`
+
+To lint: `docker compose --profile ci run --rm tests flake8 .`
 
 ## Architecture
 
 Three distinct Flask applications share templates and content:
 
-1. **`app.py`** — Main public site. Routes: `/`, `/blog/`, `/blog/<slug>/`, `/sitemap.xml`, `/robots.txt`. Site-wide config lives in the `SITE_CONFIG` dict near the top, populated from env vars. `build_page_context()` assembles the template context passed to every `render_template` call. Posts are loaded once per request via Flask's `g` object.
+1. **`app.py`** — Main public site. Routes: `/`, `/coming-soon/`, `/about/`, `/blog/<slug>/`, `/sitemap.xml`, `/robots.txt`. Site-wide config lives in `SITE_CONFIG` near the top, populated from env vars. `build_page_context()` assembles the template context for every `render_template` call. Page-level content data (`ABOUT_EXPERIENCE`, `COMING_SOON_TOPICS`) is defined as module-level constants and passed explicitly to templates — keep content out of templates.
 
-2. **`freeze.py`** — Static site generator. Uses Flask's test client to render every route to HTML files in `build/`. Respects `GITHUB_PAGES_BASE_PATH` env var (distinct from `BASE_PATH`) to rewrite paths for subdirectory deployments. Production deploys serve this frozen output via Nginx or GitHub Pages.
+2. **`freeze.py`** — Static site generator. Uses Flask's test client to render every route to HTML files in `build/`. Respects `GITHUB_PAGES_BASE_PATH` env var for subdirectory deployments. Production serves frozen output via Nginx or GitHub Pages.
 
-3. **`author_app.py`** + **`authoring_app/`** — CMS app (port 5001). Uses an application factory (`create_app()` in `authoring_app/__init__.py`). Routes are in `authoring_app/views.py` under a Blueprint at `/authoring`. Handles Markdown post creation/editing and media uploads. Not part of the public site build.
+3. **`author_app.py`** + **`authoring_app/`** — CMS app (port 5001). Application factory in `authoring_app/__init__.py`. Routes in `authoring_app/views.py` under a Blueprint at `/authoring`. Handles Markdown post creation and media uploads. Not included in the public build.
+
+### Templates
+
+- Most pages extend `base.html` using `{% block content %}`.
+- `coming-soon-full.html` is a **standalone** page — it does not extend `base.html` and has its own CSS (`static/css/coming-soon.css`).
+- No inline JavaScript in templates — all JS lives in `static/js/script.js`.
+
+### CSS Architecture
+
+`static/css/style.css` is the main entry point, importing three files:
+- `base.css` — reset, CSS variables (colours, fonts), dark mode tokens, layout, nav, footer
+- `components-core.css` — buttons, cards, home page, about page, company logos, contact form
+- `components-blog.css` — blog-specific styles
+
+`coming-soon.css` imports `base.css` directly and adds only page-specific styles. Do not duplicate CSS variables — add shared tokens to `base.css`.
 
 ### Blog Engine (`blog/`)
-- Posts live as Markdown files in `content/posts/` with YAML front matter (`title`, `slug`, `date`, optional `hero_image`)
-- `blog/utils.py` handles parsing, metadata extraction, and rendering (with syntax highlighting and safe HTML)
+
+- Posts are Markdown files in `content/posts/` with YAML front matter (`title`, `slug`, `date`, optional `hero_image`)
+- `blog/utils.py` handles parsing, rendering (with syntax highlighting), and metadata extraction
 - Content directory resolves via: `BLOG_CONTENT_DIR` → `AUTHORING_CONTENT_DIR` → `CONTENT_DIR` env vars → default `content/posts/`
 
 ### Tests (`tests/`)
-- `conftest.py` reloads the `app` module fresh for each test run to avoid import-order side effects — keep this in mind when writing fixtures that patch module-level state
-- Test files map roughly 1:1 to source files: `test_app.py`, `test_authoring_app.py`, `test_blog_utils.py`, `test_freeze_utils.py`
+
+- `conftest.py` reloads `app` fresh for each test run to avoid import-order side effects
+- Test files map 1:1 to source files: `test_app.py`, `test_authoring_app.py`, `test_blog_utils.py`, `test_freeze_utils.py`
 
 ### Environment
-- Copy `.env.example` to `.env` (or `.env.dev` for dev mode)
-- `FLASK_ENV`/`APP_ENV` controls which env file loads
-- Key vars: `BASE_PATH` (subdirectory deployments), `GITHUB_PAGES_BASE_PATH` (static build path rewriting), `PLAUSIBLE_SCRIPT_URL` / `PLAUSIBLE_DOMAIN` (optional analytics)
+
+- Copy `.env.example` to `.env.dev` for local dev
+- Dev server port is mapped `5002→5001` in `docker-compose.yml` (macOS blocks 5000)
+- Key vars: `SITE_NAME`, `SITE_EMAIL`, `SITE_LOCATION`, `SITE_GITHUB_URL`, `SITE_LINKEDIN_URL`, `BASE_PATH`, `GITHUB_PAGES_BASE_PATH`, `PLAUSIBLE_SCRIPT_URL`
 
 ## Git Commits
-Use [Conventional Commits](https://www.conventionalcommits.org/): `type(scope): description`
+
+Use [Conventional Commits](https://www.conventionalcommits.org/): `type(scope): description`  
 Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
 
 ## Branching Strategy
-This project uses **Git Flow**:
-- `master` is production — only updated via PR from `dev`
-- `dev` is the integration branch — all feature branches merge here via PR
-- Branch off `dev` for all work: `git checkout dev && git checkout -b feat/my-feature`
-- Keep branches small and focused; merge back to `dev` quickly
 
-**Branch naming convention:** `type/issue-number-short-description`
-- Type matches Conventional Commits: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`
-- Issue number ties the branch to a GitHub issue
-- Examples: `feat/137-email-signup`, `fix/142-freeze-redirect`, `chore/150-cleanup-deps`
+- `master` is production — only updated via PR from `dev`
+- `dev` is the integration branch — all feature branches merge here
+- Branch naming: `type/issue-number-short-description` e.g. `feat/137-email-signup`
 
 ## CI/CD
-- GitHub Actions runs lint → tests → static build check on PRs to `master`
-- Deployment to GitHub Pages is manual (`workflow_dispatch` only)
-- Workflows in `.github/workflows/ci.yml` and `deploy-pages.yml`
+
+GitHub Actions runs lint → tests → static build on PRs to `master`.  
+Deployment to GitHub Pages is manual (`workflow_dispatch`).  
+Workflows: `.github/workflows/ci.yml` and `deploy-pages.yml`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,11 @@ This project uses **Git Flow**:
 - Branch off `dev` for all work: `git checkout dev && git checkout -b feat/my-feature`
 - Keep branches small and focused; merge back to `dev` quickly
 
+**Branch naming convention:** `type/issue-number-short-description`
+- Type matches Conventional Commits: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`
+- Issue number ties the branch to a GitHub issue
+- Examples: `feat/137-email-signup`, `fix/142-freeze-redirect`, `chore/150-cleanup-deps`
+
 ## CI/CD
 - GitHub Actions runs lint → tests → static build check on PRs to `master`
 - Deployment to GitHub Pages is manual (`workflow_dispatch` only)

--- a/app.py
+++ b/app.py
@@ -25,6 +25,9 @@ SITE_CONFIG = {
     'plausible_script_url': os.getenv('PLAUSIBLE_SCRIPT_URL', ''),
     'plausible_domain': os.getenv('PLAUSIBLE_DOMAIN', ''),
     'social_image': os.getenv('SITE_SOCIAL_IMAGE', 'images/SreyeeshProfilePic.jpg'),
+    'github_url': os.getenv('SITE_GITHUB_URL', 'https://github.com/Sreyeesh'),
+    'linkedin_url': os.getenv('SITE_LINKEDIN_URL', 'https://www.linkedin.com/in/sreyeeshgarimella'),
+    'location': os.getenv('SITE_LOCATION', 'Estonia'),
 }
 
 NAV_LINKS = [
@@ -67,6 +70,13 @@ def build_page_context(**extra) -> dict:
 
 NOTION_SIGNUP_URL = 'https://observant-toothpaste-fa5.notion.site/64939681cd2c4a1f899c6ac8d2fe4e74?pvs=105'
 
+COMING_SOON_TOPICS = [
+    'DevOps workflows and terminal setups that actually work in production',
+    'Building tools and automation for creative studios',
+    "Full-stack development from a technical director's perspective",
+    'Lessons from shipping at Disney, Blizzard, and DNEG',
+]
+
 
 @app.route('/')
 def home():
@@ -77,7 +87,12 @@ def home():
 
 @app.route('/coming-soon/')
 def coming_soon():
-    return render_template('coming-soon-full.html', signup_url=NOTION_SIGNUP_URL)
+    return render_template(
+        'coming-soon-full.html',
+        **build_page_context(),
+        signup_url=NOTION_SIGNUP_URL,
+        topics=COMING_SOON_TOPICS,
+    )
 
 
 @app.route('/blog/')

--- a/app.py
+++ b/app.py
@@ -70,6 +70,29 @@ def build_page_context(**extra) -> dict:
 
 NOTION_SIGNUP_URL = 'https://observant-toothpaste-fa5.notion.site/64939681cd2c4a1f899c6ac8d2fe4e74?pvs=105'
 
+ABOUT_EXPERIENCE = [
+    {
+        'company': 'Walt Disney Animation Studios',
+        'role': 'Pipeline Technical Director',
+        'logo': 'images/Walt_Disney_Animation_Studios_logo.svg.png',
+    },
+    {
+        'company': 'Blizzard Entertainment',
+        'role': 'Technical Artist',
+        'logo': 'images/Blizzard_Entertainment_Logo_2015.svg.png',
+    },
+    {
+        'company': 'DNEG',
+        'role': 'Pipeline Technical Director',
+        'logo': 'images/DNEG_Animation_2025.svg.png',
+    },
+    {
+        'company': 'Boulder Media',
+        'role': 'Pipeline Developer',
+        'logo': 'images/Boulder_Media.png',
+    },
+]
+
 COMING_SOON_TOPICS = [
     'DevOps workflows and terminal setups that actually work in production',
     'Building tools and automation for creative studios',
@@ -120,7 +143,11 @@ def blog_detail(slug: str):
 
 @app.route('/about/')
 def about():
-    return redirect('/')
+    return render_template(
+        'about.html',
+        **build_page_context(page_slug='about'),
+        experience=ABOUT_EXPERIENCE,
+    )
 
 
 @app.route('/sitemap.xml')

--- a/app.py
+++ b/app.py
@@ -26,7 +26,9 @@ SITE_CONFIG = {
     'plausible_domain': os.getenv('PLAUSIBLE_DOMAIN', ''),
     'social_image': os.getenv('SITE_SOCIAL_IMAGE', 'images/SreyeeshProfilePic.jpg'),
     'github_url': os.getenv('SITE_GITHUB_URL', 'https://github.com/Sreyeesh'),
-    'linkedin_url': os.getenv('SITE_LINKEDIN_URL', 'https://www.linkedin.com/in/sreyeeshgarimella'),
+    'linkedin_url': os.getenv(
+        'SITE_LINKEDIN_URL', 'https://www.linkedin.com/in/sreyeeshgarimella'
+    ),
     'location': os.getenv('SITE_LOCATION', 'Estonia'),
 }
 
@@ -68,7 +70,10 @@ def build_page_context(**extra) -> dict:
     }
 
 
-NOTION_SIGNUP_URL = 'https://observant-toothpaste-fa5.notion.site/64939681cd2c4a1f899c6ac8d2fe4e74?pvs=105'
+NOTION_SIGNUP_URL = (
+    'https://observant-toothpaste-fa5.notion.site/'
+    '64939681cd2c4a1f899c6ac8d2fe4e74?pvs=105'
+)
 
 ABOUT_EXPERIENCE = [
     {

--- a/app.py
+++ b/app.py
@@ -70,6 +70,13 @@ NOTION_SIGNUP_URL = 'https://observant-toothpaste-fa5.notion.site/64939681cd2c4a
 
 @app.route('/')
 def home():
+    return render_template(
+        'home.html', **build_page_context(page_slug='home', posts=get_posts())
+    )
+
+
+@app.route('/coming-soon/')
+def coming_soon():
     return render_template('coming-soon-full.html', signup_url=NOTION_SIGNUP_URL)
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
         BASE_PATH: ${BASE_PATH:-/}
     container_name: toucan-ee-dev
     ports:
-      - "5000:5000"  # Map host 5000 to Flask dev server
+      - "5002:5001"  # Map host 5002 to Flask dev server
     command: python app.py
     environment:
       - FLASK_ENV=development

--- a/static/css/coming-soon.css
+++ b/static/css/coming-soon.css
@@ -1,35 +1,4 @@
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
-:root {
-    --bg:         #fafaf8;
-    --text:       #1a1a1a;
-    --text-muted: #6b6b6b;
-    --accent:     #0f62fe;
-    --border:     #e0e0de;
-    --font-serif: 'Fraunces', Georgia, serif;
-    --font-body:  'Newsreader', Georgia, serif;
-    --font-mono:  'JetBrains Mono', monospace;
-}
-
-[data-theme="dark"] {
-    --bg:         #111111;
-    --text:       #d4d4d4;
-    --text-muted: #888;
-    --accent:     #6aafff;
-    --border:     rgba(255,255,255,0.1);
-}
-
-html { scroll-behavior: smooth; }
-
-body {
-    background: var(--bg);
-    color: var(--text);
-    font-family: var(--font-body);
-    font-size: 1.125rem;
-    line-height: 1.8;
-    -webkit-font-smoothing: antialiased;
-    transition: background-color 0.2s, color 0.2s;
-}
+@import url('base.css');
 
 .topbar {
     display: flex;
@@ -72,18 +41,12 @@ body {
 }
 
 h1 {
-    font-family: var(--font-serif);
     font-size: clamp(1.75rem, 5vw, 2.25rem);
-    font-weight: 600;
-    line-height: 1.2;
-    letter-spacing: -0.02em;
-    color: var(--text);
     margin-bottom: 1.25rem;
 }
 
 .body-text {
     font-size: 1.05rem;
-    line-height: 1.8;
     color: var(--text-muted);
     max-width: 60ch;
     margin-bottom: 2rem;
@@ -122,11 +85,8 @@ hr {
 }
 
 h2 {
-    font-family: var(--font-serif);
     font-size: 1rem;
-    font-weight: 600;
     letter-spacing: -0.01em;
-    color: var(--text);
     margin-bottom: 1rem;
 }
 
@@ -157,7 +117,6 @@ h2 {
 
 .credits p {
     font-size: 0.95rem;
-    line-height: 1.8;
     color: var(--text-muted);
     max-width: 60ch;
 }

--- a/static/css/coming-soon.css
+++ b/static/css/coming-soon.css
@@ -1,0 +1,199 @@
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+    --bg:         #fafaf8;
+    --text:       #1a1a1a;
+    --text-muted: #6b6b6b;
+    --accent:     #0f62fe;
+    --border:     #e0e0de;
+    --font-serif: 'Fraunces', Georgia, serif;
+    --font-body:  'Newsreader', Georgia, serif;
+    --font-mono:  'JetBrains Mono', monospace;
+}
+
+[data-theme="dark"] {
+    --bg:         #111111;
+    --text:       #d4d4d4;
+    --text-muted: #888;
+    --accent:     #6aafff;
+    --border:     rgba(255,255,255,0.1);
+}
+
+html { scroll-behavior: smooth; }
+
+body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--font-body);
+    font-size: 1.125rem;
+    line-height: 1.8;
+    -webkit-font-smoothing: antialiased;
+    transition: background-color 0.2s, color 0.2s;
+}
+
+.topbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.25rem 1.5rem;
+    max-width: 680px;
+    margin: 0 auto;
+}
+
+.topbar-name {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    color: var(--text-muted);
+}
+
+.theme-toggle {
+    background: none;
+    border: none;
+    padding: 0.25rem;
+    cursor: pointer;
+    color: var(--text-muted);
+    display: flex;
+    align-items: center;
+    transition: color 0.15s;
+}
+
+.theme-toggle:hover { color: var(--text); }
+
+.theme-toggle .sun-icon { display: none; }
+.theme-toggle .moon-icon { display: block; }
+
+[data-theme="dark"] .theme-toggle .sun-icon { display: block; }
+[data-theme="dark"] .theme-toggle .moon-icon { display: none; }
+
+.page {
+    max-width: 680px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem 5rem;
+}
+
+h1 {
+    font-family: var(--font-serif);
+    font-size: clamp(1.75rem, 5vw, 2.25rem);
+    font-weight: 600;
+    line-height: 1.2;
+    letter-spacing: -0.02em;
+    color: var(--text);
+    margin-bottom: 1.25rem;
+}
+
+.body-text {
+    font-size: 1.05rem;
+    line-height: 1.8;
+    color: var(--text-muted);
+    max-width: 60ch;
+    margin-bottom: 2rem;
+}
+
+.body-text strong {
+    color: var(--text);
+    font-weight: 400;
+}
+
+.cta {
+    display: inline-block;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    text-decoration-thickness: 1px;
+    margin-bottom: 0.5rem;
+}
+
+.cta:hover { opacity: 0.75; }
+
+.note {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    margin-bottom: 2rem;
+}
+
+hr {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 2.5rem 0;
+}
+
+h2 {
+    font-family: var(--font-serif);
+    font-size: 1rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--text);
+    margin-bottom: 1rem;
+}
+
+.topic-list {
+    list-style: none;
+    margin-bottom: 1rem;
+}
+
+.topic-list li {
+    font-size: 0.95rem;
+    line-height: 1.7;
+    color: var(--text-muted);
+    padding: 0.5rem 0;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    gap: 1rem;
+    align-items: baseline;
+}
+
+.topic-list li:first-child { border-top: 1px solid var(--border); }
+
+.topic-list .idx {
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    color: var(--border);
+    flex-shrink: 0;
+}
+
+.credits p {
+    font-size: 0.95rem;
+    line-height: 1.8;
+    color: var(--text-muted);
+    max-width: 60ch;
+}
+
+.footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 2.5rem;
+}
+
+.footer-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.25rem;
+}
+
+.footer-links a {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    text-decoration: none;
+}
+
+.footer-links a:hover { color: var(--accent); }
+
+.footer-copy {
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    color: var(--border);
+}
+
+@media (max-width: 480px) {
+    .page { padding: 1.5rem 1.25rem 4rem; }
+    .topbar { padding: 1rem 1.25rem; }
+    .footer { flex-direction: column; align-items: flex-start; }
+}

--- a/static/css/components-core.css
+++ b/static/css/components-core.css
@@ -1398,3 +1398,97 @@ section h2 {
 }
 
 .about-body p + p { margin-top: 1.4rem; }
+
+.about-divider {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 2.5rem 0;
+}
+
+.about-credits h2,
+.about-links h2 {
+    font-family: var(--font-serif);
+    font-size: 1rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    margin-bottom: 1.25rem;
+}
+
+.credits-list {
+    list-style: none;
+}
+
+.credits-item {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.75rem 0;
+    border-bottom: 1px solid var(--border);
+}
+
+.credits-item:first-child { border-top: 1px solid var(--border); }
+
+.credits-logo {
+    width: 48px;
+    height: 32px;
+    object-fit: contain;
+    filter: grayscale(1) opacity(0.6);
+    flex-shrink: 0;
+    transition: filter 0.2s;
+}
+
+[data-theme="dark"] .credits-logo {
+    filter: grayscale(1) opacity(0.5) brightness(1.4);
+}
+
+.credits-item:hover .credits-logo {
+    filter: grayscale(0) opacity(1);
+}
+
+.credits-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+}
+
+.credits-company {
+    font-size: 0.9rem;
+    color: var(--text);
+}
+
+.credits-role {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    color: var(--text-muted);
+}
+
+.elsewhere-list {
+    list-style: none;
+}
+
+.elsewhere-list li {
+    display: flex;
+    gap: 1rem;
+    align-items: baseline;
+    padding: 0.5rem 0;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.95rem;
+}
+
+.elsewhere-list li:first-child { border-top: 1px solid var(--border); }
+
+.elsewhere-list a {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    color: var(--accent);
+    text-decoration: none;
+    flex-shrink: 0;
+    min-width: 6rem;
+}
+
+.elsewhere-list a:hover { opacity: 0.75; }
+
+.elsewhere-list span {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -52,20 +52,17 @@ document.addEventListener('DOMContentLoaded', function() {
 
         emitThemeChange(savedTheme);
 
-        // Add click event
         darkModeToggle.addEventListener('click', function(e) {
             e.preventDefault();
-            
+
             const currentTheme = document.documentElement.getAttribute('data-theme');
             const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-
 
             document.documentElement.setAttribute('data-theme', newTheme);
             localStorage.setItem('theme', newTheme);
 
             emitThemeChange(newTheme);
 
-            // Force repaint
             document.body.offsetHeight;
         });
 

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block title %}About | {{ config.name }}{% endblock %}
-{% block meta_description %}About {{ config.name }} — full-stack developer writing about software, tools, and building things.{% endblock %}
+{% block meta_description %}About {{ config.name }}, full-stack developer writing about software, tools, and building things.{% endblock %}
 
 {% block content %}
 <article class="about-page">
@@ -12,12 +12,12 @@
 
     <div class="about-body">
         <p>
-            I'm Sreyeesh Garimella — a full-stack developer and technical artist based in Estonia.
+            I'm Sreyeesh Garimella, a full-stack developer and technical artist based in Estonia.
             I've worked across games, animation, and software, building pipelines and tools at studios
             including DNEG, Blizzard, and Walt Disney Animation.
         </p>
         <p>
-            These days I'm focused on software and tooling — the kind of work that makes other
+            These days I'm focused on software and tooling, the kind of work that makes other
             work easier. I write here about things I'm building, thinking through, or learning.
             No particular cadence. Just when something is worth saying.
         </p>

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,24 +1,29 @@
 {% extends 'base.html' %}
 
 {% block title %}About | {{ config.name }}{% endblock %}
-{% block meta_description %}About {{ config.name }}, full-stack developer writing about software, tools, and building things.{% endblock %}
+{% block meta_description %}About {{ config.name }}, full-stack developer and technical director writing about software, tools, and building things.{% endblock %}
 
 {% block content %}
 <article class="about-page">
+
     <header class="about-header">
-        <img src="{{ url_for('static', filename='images/SreyeeshProfilePic.jpg') }}" alt="Sreyeesh Garimella" class="about-avatar">
+        <img
+            src="{{ url_for('static', filename='images/SreyeeshProfilePic.jpg') }}"
+            alt="{{ config.name }}"
+            class="about-avatar"
+        >
         <h1>About</h1>
     </header>
 
     <div class="about-body">
         <p>
-            I'm Sreyeesh Garimella, a full-stack developer and technical artist based in Estonia.
-            I've worked across games, animation, and software, building pipelines and tools at studios
-            including DNEG, Blizzard, and Walt Disney Animation.
+            I'm {{ config.name }}, a full-stack developer and technical director based in {{ config.location }}.
+            I've spent the last decade building pipelines and tools at animation and games studios,
+            shipping work at Disney Animation, Blizzard, and DNEG.
         </p>
         <p>
-            These days I'm focused on software and tooling, the kind of work that makes other
-            work easier. I write here about things I'm building, thinking through, or learning.
+            These days I'm focused on software and tooling — the kind of work that makes
+            other work easier. I write here about things I'm building, thinking through, or learning.
             No particular cadence. Just when something is worth saying.
         </p>
         <p>
@@ -26,5 +31,49 @@
             <a href="mailto:{{ config.email }}">{{ config.email }}</a>
         </p>
     </div>
+
+    <hr class="about-divider">
+
+    <section class="about-credits">
+        <h2>Past work</h2>
+        <ul class="credits-list">
+            {% for item in experience %}
+            <li class="credits-item">
+                <img
+                    src="{{ url_for('static', filename=item.logo) }}"
+                    alt="{{ item.company }}"
+                    class="credits-logo"
+                >
+                <div class="credits-meta">
+                    <span class="credits-company">{{ item.company }}</span>
+                    <span class="credits-role">{{ item.role }}</span>
+                </div>
+            </li>
+            {% endfor %}
+        </ul>
+    </section>
+
+    {% if config.github_url or config.linkedin_url %}
+    <hr class="about-divider">
+
+    <section class="about-links">
+        <h2>Elsewhere</h2>
+        <ul class="elsewhere-list">
+            {% if config.github_url %}
+            <li>
+                <a href="{{ config.github_url }}" target="_blank" rel="noopener noreferrer">GitHub</a>
+                <span>code and open source</span>
+            </li>
+            {% endif %}
+            {% if config.linkedin_url %}
+            <li>
+                <a href="{{ config.linkedin_url }}" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+                <span>work history</span>
+            </li>
+            {% endif %}
+        </ul>
+    </section>
+    {% endif %}
+
 </article>
 {% endblock %}

--- a/templates/blog/coming-soon.html
+++ b/templates/blog/coming-soon.html
@@ -1,6 +1,6 @@
 {% extends 'blog/base.html' %}
 
-{% block title %}Writing — Coming Soon | {{ config.name }}{% endblock %}
+{% block title %}Writing: Coming Soon | {{ config.name }}{% endblock %}
 {% block meta_description %}The blog is coming soon. Sign up to be notified when it launches.{% endblock %}
 
 {% block content %}

--- a/templates/blog/detail.html
+++ b/templates/blog/detail.html
@@ -1,6 +1,6 @@
 {% extends 'blog/base.html' %}
 
-{% block title %}{{ post.title }} — {{ config.name }} Blog{% endblock %}
+{% block title %}{{ post.title }} | {{ config.name }} Blog{% endblock %}
 {% block meta_description %}{{ post.description or post.excerpt }}{% endblock %}
 
 {% block social_meta %}

--- a/templates/blog/list.html
+++ b/templates/blog/list.html
@@ -20,6 +20,6 @@
     {% endfor %}
 </ul>
 {% else %}
-<p class="blog-empty">No posts yet — check back soon.</p>
+<p class="blog-empty">No posts yet. Check back soon.</p>
 {% endif %}
 {% endblock %}

--- a/templates/coming-soon-full.html
+++ b/templates/coming-soon-full.html
@@ -1,93 +1,88 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sreyeesh Garimella: Coming Soon</title>
-    <style>
-        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
-        body {
-            min-height: 100vh;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            background: #0f0f0f;
-            color: #e5e5e5;
-            font-family: Georgia, 'Times New Roman', serif;
-            padding: 2rem 1.25rem;
-        }
-
-        .card {
-            max-width: 520px;
-            width: 100%;
-            text-align: center;
-        }
-
-        .eyebrow {
-            font-family: system-ui, sans-serif;
-            font-size: 0.75rem;
-            font-weight: 600;
-            letter-spacing: 0.12em;
-            text-transform: uppercase;
-            color: #6b7280;
-            margin-bottom: 1.5rem;
-        }
-
-        h1 {
-            font-size: 2.25rem;
-            font-weight: 700;
-            line-height: 1.2;
-            color: #f9fafb;
-            margin-bottom: 1.25rem;
-        }
-
-        .description {
-            font-size: 1.05rem;
-            line-height: 1.75;
-            color: #9ca3af;
-            margin-bottom: 2rem;
-        }
-
-        .description strong {
-            color: #e5e7eb;
-        }
-
-        .cta {
-            display: inline-block;
-            padding: 0.85rem 2rem;
-            background: #f9fafb;
-            color: #111;
-            font-family: system-ui, sans-serif;
-            font-size: 0.95rem;
-            font-weight: 600;
-            border-radius: 6px;
-            text-decoration: none;
-            transition: background 0.15s ease;
-            margin-bottom: 1rem;
-        }
-
-        .cta:hover { background: #e5e7eb; }
-
-        .note {
-            font-family: system-ui, sans-serif;
-            font-size: 0.8rem;
-            color: #4b5563;
-        }
-    </style>
+    <title>{{ config.name }}: Coming Soon</title>
+    <meta name="description" content="{{ config.meta_description }}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,600;1,400&family=Newsreader:ital,wght@0,400;1,400&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/coming-soon.css') }}">
 </head>
 <body>
-    <div class="card">
-        <p class="eyebrow">Sreyeesh Garimella</p>
+    <div class="topbar">
+        <span class="topbar-name">{{ config.name }}</span>
+        <button class="theme-toggle" id="dark-mode-toggle" aria-label="Toggle dark mode">
+            <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="12" r="5"></circle>
+                <line x1="12" y1="1" x2="12" y2="3"></line>
+                <line x1="12" y1="21" x2="12" y2="23"></line>
+                <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+                <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+                <line x1="1" y1="12" x2="3" y2="12"></line>
+                <line x1="21" y1="12" x2="23" y2="12"></line>
+                <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+                <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+            </svg>
+            <svg class="moon-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+            </svg>
+        </button>
+    </div>
+
+    <div class="page">
+
         <h1>Something is on the way.</h1>
-        <p class="description">
-            I'm building a blog about <strong>software development, tools, and the craft of building things</strong>.
+
+        <p class="body-text">
+            A blog about <strong>software development, DevOps, and the craft of building things</strong>.
             Leave your email and I'll send you a note the moment it goes live. No spam, just one email when it's ready.
         </p>
+
         <a class="cta" href="{{ signup_url }}" target="_blank" rel="noopener noreferrer">
-            Notify me when it launches →
+            Notify me when it launches
         </a>
-        <p class="note">No Notion account needed. Just enter your email and hit submit.</p>
+        <span class="note">No Notion account needed. Just enter your email and hit submit.</span>
+
+        <hr>
+
+        <h2>What's coming</h2>
+        <ul class="topic-list">
+            {% for topic in topics %}
+            <li>
+                <span class="idx">{{ '%02d' % loop.index }}</span>
+                {{ topic }}
+            </li>
+            {% endfor %}
+        </ul>
+
+        <hr>
+
+        <div class="credits">
+            <h2>Background</h2>
+            <p>
+                Technical director and full-stack developer based in {{ config.location }}.
+                Past work includes productions at Disney Animation, Blizzard Entertainment, and DNEG.
+                Currently running SG Production OÜ and mentoring through Toucan Studios OÜ.
+            </p>
+        </div>
+
+        <div class="footer">
+            <div class="footer-links">
+                {% if config.github_url %}
+                <a href="{{ config.github_url }}" target="_blank" rel="noopener noreferrer">GitHub</a>
+                {% endif %}
+                {% if config.linkedin_url %}
+                <a href="{{ config.linkedin_url }}" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+                {% endif %}
+                <a href="mailto:{{ config.email }}">{{ config.email }}</a>
+            </div>
+            <span class="footer-copy">&copy; {{ current_year }} {{ config.name }}</span>
+        </div>
+
     </div>
+
+    <script src="{{ url_for('static', filename='js/script.js') }}"></script>
 </body>
 </html>

--- a/templates/coming-soon-full.html
+++ b/templates/coming-soon-full.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sreyeesh Garimella — Coming Soon</title>
+    <title>Sreyeesh Garimella: Coming Soon</title>
     <style>
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -82,12 +82,12 @@
         <h1>Something is on the way.</h1>
         <p class="description">
             I'm building a blog about <strong>software development, tools, and the craft of building things</strong>.
-            Leave your email and I'll send you a note the moment it goes live — no spam, just one email when it's ready.
+            Leave your email and I'll send you a note the moment it goes live. No spam, just one email when it's ready.
         </p>
         <a class="cta" href="{{ signup_url }}" target="_blank" rel="noopener noreferrer">
             Notify me when it launches →
         </a>
-        <p class="note">No Notion account needed — just enter your email and hit submit.</p>
+        <p class="note">No Notion account needed. Just enter your email and hit submit.</p>
     </div>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Break into animation and game development with industry-proven mentorship from a Disney, Blizzard & DNEG veteran. Get personalized guidance and land your dream job.">
-    <title>Animation & Game Development Mentoring — Break Into the Industry | Sreyeesh Garimella</title>
+    <title>Animation & Game Development Mentoring: Break Into the Industry | Sreyeesh Garimella</title>
     
     <!-- Open Graph Tags -->
-    <meta property="og:title" content="Animation & Game Development Mentoring — Break Into the Industry">
+    <meta property="og:title" content="Animation & Game Development Mentoring: Break Into the Industry">
     <meta property="og:description" content="Get 1-on-1 guidance from a Disney, Blizzard & DNEG veteran. Skip years of trial and error and land your dream job in animation or game development.">
     <meta property="og:image" content="{{ url_for('static', filename='images/SreyeeshProfilePic.jpg') }}">
     
@@ -64,7 +64,7 @@
                 <div class="hero-content">
                     <h1>Production-ready mentoring for artists, developers, and indie teams.</h1>
                     <p class="hero-subtitle">
-                        I run Toucan Studios OÜ where I mentor game developers, animation students, and creative teams—partnering with Game City Kajaani to provide technical guidance, creative direction, and hands-on coaching that ships real projects.
+                        I run Toucan Studios OÜ where I mentor game developers, animation students, and creative teams, partnering with Game City Kajaani to provide technical guidance, creative direction, and hands-on coaching that ships real projects.
                     </p>
                     <p class="hero-subtitle">
                         As Owner &amp; Technical Director at SG Production OÜ, I build full-stack tools and automation that help studios align art, engineering, and production so they can deliver at industry standards.
@@ -108,8 +108,8 @@
         <div class="wrap">
             <h2>Why Work With an Industry Veteran?</h2>
             <div class="about-content">
-                <p>I’m not just another online course creator—I’m an active technical director who has contributed to flagship productions at <strong>Disney</strong>, <strong>Blizzard Entertainment</strong>, and <strong>DNEG</strong>, while mentoring with <strong>Game City Kajaani</strong>.</p>
-                <p>Credits on <em>Overwatch 2</em>, <em>My Little Pony: A New Generation</em>, and <em>Garfield</em> mean I know exactly how studios brief, review, and ship work—and that’s the standard I bring into every tutoring engagement.</p>
+                <p>I’m not just another online course creator. I’m an active technical director who has contributed to flagship productions at <strong>Disney</strong>, <strong>Blizzard Entertainment</strong>, and <strong>DNEG</strong>, while mentoring with <strong>Game City Kajaani</strong>.</p>
+                <p>Credits on <em>Overwatch 2</em>, <em>My Little Pony: A New Generation</em>, and <em>Garfield</em> mean I know exactly how studios brief, review, and ship work. That’s the standard I bring into every tutoring engagement.</p>
                 <p>Whether you’re a junior trying to land your first role or an independent creator aligning art and engineering, you get clear, actionable feedback rooted in live production experience.</p>
                 <div style="text-align: center; margin-top: 30px;">
                     <a href="#contact" class="cta-button">Book Your Free Strategy Call</a>
@@ -185,7 +185,7 @@
 
     <section class="about" id="sg-production">
         <div class="wrap">
-            <h2>SG Production OÜ — Owner &amp; Technical Director</h2>
+            <h2>SG Production OÜ, Owner &amp; Technical Director</h2>
             <div class="about-content">
                 <p>Since July 2022 I’ve led SG Production OÜ remotely from Valgjärve, Estonia, delivering full-stack web development and creative pipeline automation for animation, VFX, and game studios worldwide. I bridge technology and creativity by building platforms and tools that keep distributed teams aligned.</p>
                 <p>Key contributions:</p>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,10 +9,10 @@ def test_home_page(client):
 
 
 def test_home_page_content(client):
-    """Coming soon page has signup link and no-account note."""
+    """Home page has key content."""
     response = client.get('/')
-    assert b'notion.site' in response.data
-    assert b'Notion account' in response.data
+    assert b'Sreyeesh Garimella' in response.data
+    assert b'Writing' in response.data
 
 
 def test_pages_load(client):


### PR DESCRIPTION
## Summary
- Built and styled coming-soon landing page with dark mode icon toggle, Jinja2 loop for topics, and extracted CSS to `coming-soon.css`
- Developed about page with experience section using company logos, driven by `ABOUT_EXPERIENCE` data in `app.py`
- Removed em dashes from all templates
- Fixed lint errors and updated CLAUDE.md with correct ports and Docker-only workflow
- Added AI tooling files to `.gitignore`

## Test plan
- [ ] `make test` passes (18/18)
- [ ] `flake8` passes
- [ ] `python freeze.py` builds successfully
- [ ] `/coming-soon/` renders with dark mode toggle and topic list
- [ ] `/about/` renders with profile image and experience section