### PR TITLE
fix(freeze): add coming-soon route to static build

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -38,6 +38,7 @@ def build_static_site() -> None:
                 ('/', BUILD_DIR / 'index.html'),
                 ('/blog/', BUILD_DIR / 'blog' / 'index.html'),
                 ('/about/', BUILD_DIR / 'about' / 'index.html'),
+                ('/coming-soon/', BUILD_DIR / 'coming-soon' / 'index.html'),
             ]
             for route, destination in static_routes:
                 response = client.get(route, follow_redirects=True)


### PR DESCRIPTION
## Summary
- `/coming-soon/` was missing from `freeze.py` so it was never included in the GitHub Pages deploy

## Test plan
- [ ] `make test` passes
- [ ] `python freeze.py` generates `coming-soon/index.html`