### PR TITLE
fix(routing): serve coming-soon at / until blog is ready

### DIFF
--- a/app.py
+++ b/app.py
@@ -109,17 +109,17 @@ COMING_SOON_TOPICS = [
 @app.route('/')
 def home():
     return render_template(
-        'home.html', **build_page_context(page_slug='home', posts=get_posts())
-    )
-
-
-@app.route('/coming-soon/')
-def coming_soon():
-    return render_template(
         'coming-soon-full.html',
         **build_page_context(),
         signup_url=NOTION_SIGNUP_URL,
         topics=COMING_SOON_TOPICS,
+    )
+
+
+@app.route('/home/')
+def home_full():
+    return render_template(
+        'home.html', **build_page_context(page_slug='home', posts=get_posts())
     )
 
 

--- a/freeze.py
+++ b/freeze.py
@@ -36,9 +36,9 @@ def build_static_site() -> None:
         with app.test_client() as client:
             static_routes = [
                 ('/', BUILD_DIR / 'index.html'),
+                ('/home/', BUILD_DIR / 'home' / 'index.html'),
                 ('/blog/', BUILD_DIR / 'blog' / 'index.html'),
                 ('/about/', BUILD_DIR / 'about' / 'index.html'),
-                ('/coming-soon/', BUILD_DIR / 'coming-soon' / 'index.html'),
             ]
             for route, destination in static_routes:
                 response = client.get(route, follow_redirects=True)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,10 +9,10 @@ def test_home_page(client):
 
 
 def test_home_page_content(client):
-    """Home page has key content."""
+    """Home page shows coming soon content."""
     response = client.get('/')
     assert b'Sreyeesh Garimella' in response.data
-    assert b'Writing' in response.data
+    assert b'Something is on the way' in response.data
 
 
 def test_pages_load(client):


### PR DESCRIPTION
## Summary
- `/` now serves the coming-soon page instead of the home page
- Full home page moved to `/home/` for local dev access
- `freeze.py` updated to match new routing

## Test plan
- [ ] `make test` passes
- [ ] `toucan.ee` shows coming-soon page