### PR TITLE
chore(deps): upgrade Flask 2.3.3→3.1.3 and gunicorn 21.2.0→23.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-Flask==2.3.3
+Flask==3.1.3
 python-dotenv==1.0.0
-gunicorn==21.2.0
+gunicorn==23.0.0
 pytest==7.4.3
 pytest-cov==4.1.0
 flake8==6.1.0


### PR DESCRIPTION
## Summary

Upgrades two dependencies for security and maintenance reasons.

- `gunicorn` 21.2.0 → 23.0.0 — fixes CVE-2024-6827 (HTTP request smuggling, CVSS 7.5 High)
- `Flask` 2.3.3 → 3.1.3 — Flask 2.3.x is EOL and no longer receives security patches

No deprecated Flask 2.x APIs (`flask.escape`, `flask.Markup`, `FLASK_ENV`) were found in the codebase — no additional migration needed.

Closes #157

---

## Testing

### Pull latest changes locally

```bash
git fetch origin
git checkout dev
git pull origin dev
git checkout chore/157-upgrade-gunicorn-flask
git pull origin chore/157-upgrade-gunicorn-flask
```

### Run tests via Docker

```bash
make test
```

Expected output:
```
18 passed
```

### Start the dev server and verify manually

```bash
make run
```

Then open http://localhost:5002 and check:
- [ ] Home / coming soon page loads
- [ ] About page loads
- [ ] Blog index loads
- [ ] A blog post loads
- [ ] No 500 errors in the terminal output

### Build and run the production container

```bash
make docker-build && make docker-up
```

Then open http://localhost:3000 and confirm the site serves correctly.

---

## Checklist

- [ ] `gunicorn` updated to `23.0.0`
- [ ] `Flask` updated to `3.1.3`
- [ ] No deprecated Flask 2.x APIs in codebase
- [ ] Tests pass via `make test`
- [ ] Dev server runs cleanly via `make run`
- [ ] Production container builds and serves via `make docker-build && make docker-up`