### PR TITLE
feat(ci): auto-deploy to GitHub Pages on master push

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,6 +1,9 @@
 name: Deploy to GitHub Pages
 
 on:
+  push:
+    branches:
+      - master
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
Adds a `push` trigger on `master` to `.github/workflows/deploy-pages.yml` so PRs merged into `master` deploy to GitHub Pages automatically. `workflow_dispatch` is preserved as a manual fallback.

The deploy job already has `if: github.ref == 'refs/heads/master'`, so manual dispatches from other refs continue to only build the artifact without publishing.

## Test plan
- [ ] Verify next push to `master` triggers the workflow
- [ ] Verify `workflow_dispatch` still runs manually
- [ ] Confirm artifact uploads and deploy job runs only for master refs

Closes #146