### PR TITLE
fix(meta): populate og:image for social shares

### DIFF
--- a/app.py
+++ b/app.py
@@ -57,15 +57,25 @@ def build_absolute_url(path: str) -> str:
     return f'{request.url_root.rstrip("/")}{normalized}'
 
 
+def build_social_image_url() -> str:
+    social_image = SITE_CONFIG['social_image']
+    if social_image.startswith(('http://', 'https://')):
+        return social_image
+    static_path = url_for('static', filename=social_image)
+    return build_absolute_url(static_path)
+
+
 def build_page_context(**extra) -> dict:
-    return {
+    context = {
         'config': SITE_CONFIG,
         'current_year': datetime.now().year,
         'nav_links': NAV_LINKS,
         'site_links': SITE_LINKS,
         'canonical_url': build_absolute_url(request.path),
-        **extra,
+        'social_image_url': build_social_image_url(),
     }
+    context.update(extra)
+    return context
 
 
 MENTORING_BOOKING_URL = os.getenv(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -15,6 +15,22 @@ def test_home_page_content(client):
     assert b'Book a session' in response.data
 
 
+def test_home_page_has_og_image(client):
+    """og:image meta tag must resolve to a non-empty absolute URL."""
+    response = client.get('/')
+    html = response.data.decode()
+    import re
+    match = re.search(
+        r'<meta property="og:image" content="([^"]*)"', html
+    )
+    assert match is not None, 'og:image meta tag missing'
+    url = match.group(1)
+    assert url, 'og:image content is empty'
+    assert url.startswith(('http://', 'https://')), (
+        f'og:image must be absolute, got: {url}'
+    )
+
+
 def test_pages_load(client):
     """Blog index renders the post list."""
     response = client.get('/blog/')


### PR DESCRIPTION
## Summary
`templates/base.html` referenced `{{ social_image_url }}` but `build_page_context()` in `app.py` never set it, so `og:image` and `twitter:image` rendered with empty `content=""` — blank previews on LinkedIn, X, iMessage.

- Compute `social_image_url` in `build_page_context()` from `SITE_CONFIG['social_image']`, resolved to an absolute URL via `build_absolute_url`.
- External URLs in `SITE_SOCIAL_IMAGE` pass through untouched.
- Adds `test_home_page_has_og_image` asserting a non-empty absolute og:image URL.

## Follow-up (not in this PR)
The default `social_image` still points at `images/SreyeeshProfilePic.jpg` (square-ish). For best results, drop a proper 1200×630 OG image in `static/images/` and set `SITE_SOCIAL_IMAGE` to its path. Plumbing now ensures it renders correctly once supplied.

## Test plan
- [x] `make test` — 19/19 pass (new regression test included)
- [ ] Verify on staging: view-source on `/`, `/about/`, `/blog/<slug>/` shows non-empty absolute `og:image`
- [ ] Run through the LinkedIn Post Inspector or Twitter Card Validator against a deployed URL

Closes #168