### PR TITLE
chore(dev): use standard port 5000 for dev server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 All commands run inside Docker via the Makefile — never use local Python or venv directly.
 
 - `make install` — Build all Docker images
-- `make run` — Start dev container with hot reload (http://localhost:5002)
+- `make run` — Start dev container with hot reload (http://localhost:5000)
 - `make test` — Run pytest suite in Docker
 - `make freeze` — Generate static build into `build/`
 - `make docker-build` / `make docker-up` — Build/run production container (:3000)
@@ -58,7 +58,6 @@ Three distinct Flask applications share templates and content:
 ### Environment
 
 - Copy `.env.example` to `.env.dev` for local dev
-- Dev server port is mapped `5002→5001` in `docker-compose.yml` (macOS blocks 5000)
 - Key vars: `SITE_NAME`, `SITE_EMAIL`, `SITE_LOCATION`, `SITE_GITHUB_URL`, `SITE_LINKEDIN_URL`, `BASE_PATH`, `GITHUB_PAGES_BASE_PATH`, `PLAUSIBLE_SCRIPT_URL`
 
 ## Git Commits

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
         BASE_PATH: ${BASE_PATH:-/}
     container_name: toucan-ee-dev
     ports:
-      - "5002:5001"  # Map host 5002 to Flask dev server
+      - "5000:5000"
     command: python app.py
     environment:
       - FLASK_ENV=development


### PR DESCRIPTION
Closes #203.

## Summary
- Drops the macOS AirDrop workaround (host 5002 → container 5001) now that development is on Linux
- Dev server runs on http://localhost:5000, matching the Makefile help text and Flask's default
- `docker-compose.yml`: dev mapping is now `5000:5000`
- `CLAUDE.md`: URL updated, macOS note removed
- Authoring CMS unchanged (still :5001)

## Test plan
- [x] `make run` serves on http://localhost:5000 (verified, HTTP 200)
- [x] `make authoring` still works on http://localhost:5001
- [ ] Reviewer runs `make run` and confirms :5000 works on their machine

## Note for local devs
Update your local `.env.dev` to `PORT=5000` (the file is gitignored).