### PR TITLE
content(about): rewrite page, remove past work section, add SEO

### DIFF
--- a/app.py
+++ b/app.py
@@ -83,29 +83,6 @@ MENTORING_BOOKING_URL = os.getenv(
     'https://cal.com/sreyeesh-dhb2sk/60min',
 )
 
-ABOUT_EXPERIENCE = [
-    {
-        'company': 'Walt Disney Animation Studios',
-        'role': 'Pipeline Technical Director',
-        'logo': 'images/Walt_Disney_Animation_Studios_logo.svg.png',
-    },
-    {
-        'company': 'Blizzard Entertainment',
-        'role': 'Technical Artist',
-        'logo': 'images/Blizzard_Entertainment_Logo_2015.svg.png',
-    },
-    {
-        'company': 'DNEG',
-        'role': 'Pipeline Technical Director',
-        'logo': 'images/DNEG_Animation_2025.svg.png',
-    },
-    {
-        'company': 'Boulder Media',
-        'role': 'Pipeline Developer',
-        'logo': 'images/Boulder_Media.png',
-    },
-]
-
 LANDING_PAGE = {
     'page_title': 'Game Dev Mentoring',
     'eyebrow': '1:1 Game Dev Mentoring',
@@ -220,7 +197,6 @@ def about():
     return render_template(
         'about.html',
         **build_page_context(page_slug='about'),
-        experience=ABOUT_EXPERIENCE,
     )
 
 

--- a/static/css/components-core.css
+++ b/static/css/components-core.css
@@ -1405,62 +1405,23 @@ section h2 {
     margin: 2.5rem 0;
 }
 
-.about-credits h2,
+.about-body h2,
 .about-links h2 {
     font-family: var(--font-serif);
-    font-size: 1rem;
+    font-size: 1.15rem;
     font-weight: 600;
     letter-spacing: -0.01em;
-    margin-bottom: 1.25rem;
+    margin-top: 2rem;
+    margin-bottom: 1rem;
 }
 
-.credits-list {
-    list-style: none;
-}
-
-.credits-item {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    padding: 0.75rem 0;
-    border-bottom: 1px solid var(--border);
-}
-
-.credits-item:first-child { border-top: 1px solid var(--border); }
-
-.credits-logo {
-    width: 48px;
-    height: 32px;
-    object-fit: contain;
-    filter: grayscale(1) opacity(0.6);
-    flex-shrink: 0;
-    transition: filter 0.2s;
-}
-
-[data-theme="dark"] .credits-logo {
-    filter: grayscale(1) opacity(0.5) brightness(1.4);
-}
-
-.credits-item:hover .credits-logo {
-    filter: grayscale(0) opacity(1);
-}
-
-.credits-meta {
-    display: flex;
-    flex-direction: column;
-    gap: 0.1rem;
-}
-
-.credits-company {
-    font-size: 0.9rem;
+.about-body a {
     color: var(--text);
+    text-decoration: underline;
+    text-underline-offset: 3px;
 }
 
-.credits-role {
-    font-family: var(--font-mono);
-    font-size: 0.7rem;
-    color: var(--text-muted);
-}
+.about-body a:hover { opacity: 0.75; }
 
 .elsewhere-list {
     list-style: none;

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
-{% block title %}About | {{ config.name }}{% endblock %}
-{% block meta_description %}About {{ config.name }}, full-stack developer and technical director writing about software, tools, and building things.{% endblock %}
+{% block title %}About | Game Dev Mentor — {{ config.name }}{% endblock %}
+{% block meta_description %}{{ config.name }} offers 1:1 game development mentoring for beginners, hobbyists, and indie teams. Industry experience at Blizzard Entertainment, currently mentoring at GameCityKajaani.{% endblock %}
 
 {% block content %}
 <article class="about-page">
@@ -9,7 +9,7 @@
     <header class="about-header">
         <img
             src="{{ url_for('static', filename='images/SreyeeshProfilePic.jpg') }}"
-            alt="{{ config.name }}"
+            alt="{{ config.name }}, game development mentor"
             class="about-avatar"
         >
         <h1>About</h1>
@@ -17,41 +17,31 @@
 
     <div class="about-body">
         <p>
-            I'm {{ config.name }}, a full-stack developer and technical director based in {{ config.location }}.
-            I've spent the last decade building pipelines and tools at animation and games studios,
-            shipping work at Disney Animation, Blizzard, and DNEG.
+            I'm {{ config.name }}, a 1:1 game development mentor based in {{ config.location }}.
+            I help complete beginners, hobbyists, and small indie teams get started in game dev,
+            pick the right engine, and finish the projects they start.
         </p>
+
+        <h2>Background</h2>
         <p>
-            These days I'm focused on software and tooling, the kind of work that makes
-            other work easier. I write here about things I'm building, thinking through, or learning.
-            No particular cadence. Just when something is worth saying.
+            I've spent over a decade working in the games and animation industries,
+            most notably as a technical artist at Blizzard Entertainment. I currently
+            mentor aspiring game developers at GameCityKajaani, working with students
+            at every stage, from people who have never opened a game engine to teams
+            shipping their first commercial project.
         </p>
+
+        <h2>How I can help</h2>
         <p>
-            If you want to get in touch, email is the best way:
-            <a href="mailto:{{ config.email }}">{{ config.email }}</a>
+            Whether you are choosing between Godot, Unity, or Unreal, scoping your
+            first playable prototype, or pushing through the messy middle of a side
+            project, I offer focused 60-minute video sessions tailored to where you
+            actually are. Sessions are €75 each, with no long-term commitment.
+            <a href="/">Book a session</a>, or email
+            <a href="mailto:{{ config.email }}">{{ config.email }}</a> if you have
+            questions first.
         </p>
     </div>
-
-    <hr class="about-divider">
-
-    <section class="about-credits">
-        <h2>Past work</h2>
-        <ul class="credits-list">
-            {% for item in experience %}
-            <li class="credits-item">
-                <img
-                    src="{{ url_for('static', filename=item.logo) }}"
-                    alt="{{ item.company }}"
-                    class="credits-logo"
-                >
-                <div class="credits-meta">
-                    <span class="credits-company">{{ item.company }}</span>
-                    <span class="credits-role">{{ item.role }}</span>
-                </div>
-            </li>
-            {% endfor %}
-        </ul>
-    </section>
 
     {% if config.github_url or config.linkedin_url %}
     <hr class="about-divider">

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block title %}About | Game Dev Mentor — {{ config.name }}{% endblock %}
-{% block meta_description %}{{ config.name }} offers 1:1 game development mentoring for beginners, hobbyists, and indie teams. Industry experience at Blizzard Entertainment, currently mentoring at GameCityKajaani.{% endblock %}
+{% block meta_description %}1:1 game development mentoring for beginners, hobbyists, and indie teams. Blizzard Entertainment alumni, currently mentoring at GameCityKajaani.{% endblock %}
 
 {% block content %}
 <article class="about-page">
@@ -26,9 +26,9 @@
         <p>
             I've spent over a decade working in the games and animation industries,
             most notably as a technical artist at Blizzard Entertainment. I currently
-            mentor aspiring game developers at GameCityKajaani, working with students
-            at every stage, from people who have never opened a game engine to teams
-            shipping their first commercial project.
+            mentor aspiring game developers remotely with GameCityKajaani in Finland,
+            working with students at every stage, from people who have never opened a
+            game engine to teams shipping their first commercial project.
         </p>
 
         <h2>How I can help</h2>
@@ -37,7 +37,7 @@
             first playable prototype, or pushing through the messy middle of a side
             project, I offer focused 60-minute video sessions tailored to where you
             actually are. Sessions are €75 each, with no long-term commitment.
-            <a href="/">Book a session</a>, or email
+            <a href="{{ site_links.home }}">Book a session</a>, or email
             <a href="mailto:{{ config.email }}">{{ config.email }}</a> if you have
             questions first.
         </p>


### PR DESCRIPTION
Closes #202. Part of epic #199.

## Summary
- Removes `ABOUT_EXPERIENCE` constant and the "Past work" credits section (Disney, Blizzard, DNEG, Boulder Media)
- Rewrites about-page prose around 1:1 game dev mentoring positioning
- Adds SEO: new `<title>`, meta description, image alt, two `<h2>` subsections (Background, How I can help), internal link to landing CTA
- Adds `.about-body h2` and `.about-body a` CSS; removes ~50 lines of dead `.credits-*` styles
- Blizzard retained as credential; GameCityKajaani added as current role

## Test plan
- [x] `make test` passes (19/19)
- [x] `/about/` renders without template errors
- [x] Reviewer hard-refreshes `/about/` and confirms styling on h2s and inline links
- [x] Reviewer checks no broken image references (Disney/DNEG/Boulder PNGs are no longer referenced; assets remain on disk for now)