### PR TITLE
content(config): update tagline and meta description

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,13 +13,14 @@ from blog import find_post, load_posts, normalize_media_path  # noqa: E402
 
 SITE_CONFIG = {
     'name': os.getenv('SITE_NAME', 'Sreyeesh Garimella'),
-    'tagline': os.getenv('SITE_TAGLINE', 'Full-Stack Developer · Toucan.ee'),
+    'tagline': os.getenv('SITE_TAGLINE', 'Toucan Studios · 1:1 Game Dev Mentoring'),
     'email': os.getenv('SITE_EMAIL', 'toucan.sg@gmail.com'),
     'site_url': os.getenv('SITE_URL', '').rstrip('/'),
     'meta_description': os.getenv(
         'SITE_META_DESCRIPTION',
-        '1:1 game development mentoring for beginners, hobbyists, and indie '
-        'teams. Engine-agnostic. Godot, Unity, Unreal, or your own.',
+        '1:1 game development mentoring at Toucan Studios. '
+        'For complete beginners, hobbyists, and indie teams. '
+        '60-minute video sessions, €75 each.',
     ),
     'asset_version': os.getenv('ASSET_VERSION', '1'),
     'plausible_script_url': os.getenv('PLAUSIBLE_SCRIPT_URL', ''),


### PR DESCRIPTION
Closes #201. Final sub-task of epic #199.

## Summary
- Tagline: \`Full-Stack Developer · Toucan.ee\` → \`Toucan Studios · 1:1 Game Dev Mentoring\`
- Meta description: rewritten to lead with 1:1 game dev mentoring at Toucan Studios, include audience and offer (60 min, €75)
- Scope-locked to \`SITE_CONFIG\` per issue acceptance criteria

## Out of scope (follow-up)
Full rebrand to Toucan Studios OÜ (`SITE_CONFIG.name`, footer copyright, about-page template) is tracked in a separate issue, since it cascades into prose changes.

## Test plan
- [x] \`make test\` passes (19/19)
- [ ] Reviewer verifies tagline in nav/header and meta description on home page