### PR TITLE
content(rebrand): use Toucan Studios brand and OÜ legal name across site

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,8 @@ from blog import find_post, load_posts, normalize_media_path  # noqa: E402
 
 SITE_CONFIG = {
     'name': os.getenv('SITE_NAME', 'Sreyeesh Garimella'),
+    'brand_name': os.getenv('SITE_BRAND_NAME', 'Toucan Studios'),
+    'brand_legal_name': os.getenv('SITE_BRAND_LEGAL_NAME', 'Toucan Studios OÜ'),
     'tagline': os.getenv('SITE_TAGLINE', 'Toucan Studios · 1:1 Game Dev Mentoring'),
     'email': os.getenv('SITE_EMAIL', 'toucan.sg@gmail.com'),
     'site_url': os.getenv('SITE_URL', '').rstrip('/'),

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 
-{% block title %}About | Game Dev Mentor — {{ config.name }}{% endblock %}
+{% block title %}About | {{ config.brand_name }}{% endblock %}
 {% block meta_description %}1:1 game development mentoring for beginners, hobbyists, and indie teams. Blizzard Entertainment alumni, currently mentoring at GameCityKajaani.{% endblock %}
 
 {% block content %}
@@ -17,9 +17,10 @@
 
     <div class="about-body">
         <p>
-            I'm {{ config.name }}, a 1:1 game development mentor based in {{ config.location }}.
-            I help complete beginners, hobbyists, and small indie teams get started in game dev,
-            pick the right engine, and finish the projects they start.
+            I'm {{ config.name }}, the mentor at {{ config.brand_name }}, based in {{ config.location }}.
+            I offer 1:1 game development mentoring for complete beginners, hobbyists, and small
+            indie teams: get started in game dev, pick the right engine, and finish the projects
+            you start.
         </p>
 
         <h2>Background</h2>

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,12 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     {% set page_title = (self.title() | striptags) %}
     {% set page_description = (self.meta_description() | striptags) %}
-    <title>{% block title %}{{ config.name }} | Toucan.ee{% endblock %}</title>
+    <title>{% block title %}{{ config.brand_name }}{% endblock %}</title>
     <meta name="description" content="{% block meta_description %}{{ config.meta_description }}{% endblock %}">
     {% block social_meta %}
         <link rel="canonical" href="{{ canonical_url }}">
         <meta property="og:type" content="website">
-        <meta property="og:site_name" content="{{ config.name }}">
+        <meta property="og:site_name" content="{{ config.brand_name }}">
         <meta property="og:title" content="{{ page_title }}">
         <meta property="og:description" content="{{ page_description }}">
         <meta property="og:url" content="{{ canonical_url }}">
@@ -48,7 +48,7 @@
     <nav class="navbar" aria-label="Primary">
         <div class="nav-content">
             <div class="nav-brand">
-                <a href="{{ site_links.home }}" class="nav-name-link">{{ config.name }}</a>
+                <a href="{{ site_links.home }}" class="nav-name-link">{{ config.brand_legal_name }}</a>
             </div>
             <div class="nav-links" id="nav-links">
                 {% for item in nav_links %}
@@ -94,7 +94,7 @@
 
     <footer>
         <div class="wrap">
-            <p>&copy; {{ current_year }} {{ config.name }}</p>
+            <p>&copy; {{ current_year }} {{ config.brand_legal_name }}</p>
             <a href="mailto:{{ config.email }}">{{ config.email }}</a>
         </div>
     </footer>

--- a/templates/blog/base.html
+++ b/templates/blog/base.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
-{% block title %}{{ config.name }} Blog{% endblock %}
-{% block meta_description %}Writing by {{ config.name }} on software, development, and building things.{% endblock %}
+{% block title %}Writing | {{ config.brand_name }}{% endblock %}
+{% block meta_description %}Writing by {{ config.name }} on game development, mentoring, and building things.{% endblock %}
 
 {% block body_class %}blog-layout{% endblock %}
 {% block main_class %}blog-main{% endblock %}

--- a/templates/blog/coming-soon.html
+++ b/templates/blog/coming-soon.html
@@ -1,6 +1,6 @@
 {% extends 'blog/base.html' %}
 
-{% block title %}Writing: Coming Soon | {{ config.name }}{% endblock %}
+{% block title %}Writing: Coming Soon | {{ config.brand_name }}{% endblock %}
 {% block meta_description %}The blog is coming soon. Sign up to be notified when it launches.{% endblock %}
 
 {% block content %}

--- a/templates/blog/detail.html
+++ b/templates/blog/detail.html
@@ -1,6 +1,6 @@
 {% extends 'blog/base.html' %}
 
-{% block title %}{{ post.title }} | {{ config.name }} Blog{% endblock %}
+{% block title %}{{ post.title }} | {{ config.brand_name }}{% endblock %}
 {% block meta_description %}{{ post.description or post.excerpt }}{% endblock %}
 
 {% block social_meta %}
@@ -23,7 +23,7 @@
 
     <link rel="canonical" href="{{ canonical_url }}">
     <meta property="og:type" content="article">
-    <meta property="og:site_name" content="{{ config.name }}">
+    <meta property="og:site_name" content="{{ config.brand_name }}">
     <meta property="og:title" content="{{ post.title }}">
     {% if social_description %}
         <meta property="og:description" content="{{ social_description }}">

--- a/templates/blog/list.html
+++ b/templates/blog/list.html
@@ -1,6 +1,6 @@
 {% extends 'blog/base.html' %}
 
-{% block title %}Writing | {{ config.name }}{% endblock %}
+{% block title %}Writing | {{ config.brand_name }}{% endblock %}
 
 {% block content %}
 <div class="blog-list-header">

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 
-{% block title %}{{ config.name }} | {{ landing.page_title }}{% endblock %}
+{% block title %}{{ config.brand_name }} | {{ landing.page_title }}{% endblock %}
 {% block meta_description %}{{ config.meta_description }}{% endblock %}
 
 {% block head_extra %}


### PR DESCRIPTION
Closes #208.

## Summary
- Adds \`brand_name\` (\"Toucan Studios\") and \`brand_legal_name\` (\"Toucan Studios OÜ\") to \`SITE_CONFIG\`
- Keeps \`name\` (\"Sreyeesh Garimella\") for first-person prose and blog byline
- Updates 11 template references to use brand or legal name as appropriate
- Navbar displays full legal name \"Toucan Studios OÜ\"
- Footer copyright uses legal name
- About-page intro rewritten to introduce both person and brand: \"I'm Sreyeesh Garimella, the mentor at Toucan Studios, based in Estonia.\"
- Drops stale \"Toucan.ee\" from default page title

## Naming convention applied
- **Toucan Studios** (display brand): nav, page titles, og:site_name, body marketing copy
- **Toucan Studios OÜ** (legal entity): navbar header, footer copyright
- **Sreyeesh Garimella** (operator): first-person prose, blog byline, image alt

## Out of scope (follow-up)
\`templates/index.html\` is an orphaned dead template (no route, no includes) with hardcoded brand prose. Worth a cleanup issue but left alone here.

## Test plan
- [x] \`make test\` passes (19/19)
- [x] Home page renders with new brand in title, nav, footer
- [x] About page intro reads naturally with both person + brand
- [x] OÜ character (Ü with umlaut) preserved everywhere
- [ ] Reviewer verifies blog pages (index + a post) show new title structure