### PR TITLE
chore(ci): read SITE_COMING_SOON from GitHub Actions variable

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -23,7 +23,7 @@ jobs:
       SITE_URL: ${{ vars.SITE_URL }}
       BASE_PATH: ${{ vars.BASE_PATH }}
       GITHUB_PAGES_BASE_PATH: ${{ vars.BASE_PATH }}
-      SITE_COMING_SOON: 'true'
+      SITE_COMING_SOON: ${{ vars.SITE_COMING_SOON }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Replaces the hardcoded \`SITE_COMING_SOON: 'true'\` in the deploy workflow with \`vars.SITE_COMING_SOON\`

## Why
To launch the real site, the previous approach required editing and committing workflow YAML — a code change to flip a business state. Now it's a toggle in GitHub Settings → Variables, no commit needed.

## Action required after merge
Set the variable in GitHub: **Settings → Secrets and variables → Actions → Variables → New repository variable**
- Name: \`SITE_COMING_SOON\`
- Value: \`true\` (keep coming-soon mode) or \`false\` (go live)

## Test plan
- [ ] CI passes
- [ ] Confirm \`SITE_COMING_SOON\` variable exists in GitHub repo settings before next deploy