### PR TITLE
chore(ci): pass SITE_COMING_SOON to build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
         run: pytest
 
       - name: Build static site
+        env:
+          SITE_COMING_SOON: ${{ vars.SITE_COMING_SOON }}
         run: |
           set -euo pipefail
           python freeze.py


### PR DESCRIPTION
## Summary
- Adds `SITE_COMING_SOON: ${{ vars.SITE_COMING_SOON }}` to the CI build step

## Why
CI was building the real landing page (no flag set) while the deploy workflow was shipping the coming-soon page. A bug in the coming-soon template would pass CI undetected and only surface on the live site. Now both CI and deploy read the same variable, so they build the same artifact.

## Test plan
- [x] CI passes
- [x] Build step in CI now respects the `SITE_COMING_SOON` repo variable