### PR TITLE
hotfix: restore coming-soon gate, make deploy manual-only

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,9 +1,6 @@
 name: Deploy to GitHub Pages
 
 on:
-  push:
-    branches:
-      - master
   workflow_dispatch:
 
 permissions:

--- a/app.py
+++ b/app.py
@@ -50,6 +50,14 @@ def get_posts():
     return g.posts
 
 
+def is_coming_soon() -> bool:
+    return os.getenv('SITE_COMING_SOON', 'false').lower() == 'true'
+
+
+def coming_soon_response():
+    return render_template('coming-soon-launch.html', config=SITE_CONFIG)
+
+
 def build_absolute_url(path: str) -> str:
     site_url = SITE_CONFIG['site_url']
     normalized = path if path.startswith('/') else f'/{path}'
@@ -163,6 +171,8 @@ LANDING_PAGE = {
 
 @app.route('/')
 def home():
+    if is_coming_soon():
+        return coming_soon_response()
     return render_template(
         'landing.html',
         **build_page_context(page_slug='home'),
@@ -173,6 +183,8 @@ def home():
 
 @app.route('/blog/')
 def blog_index():
+    if is_coming_soon():
+        return coming_soon_response()
     return render_template(
         'blog/list.html',
         **build_page_context(page_slug='blog', posts=get_posts()),
@@ -200,6 +212,8 @@ def blog_detail(slug: str):
 
 @app.route('/about/')
 def about():
+    if is_coming_soon():
+        return coming_soon_response()
     return render_template(
         'about.html',
         **build_page_context(page_slug='about'),


### PR DESCRIPTION
## What happened
Merging dev → master (#217) removed the coming-soon gate from app.py (dev had it removed). The deploy workflow also auto-triggered on push to master, immediately shipping the real site live.

## This fix
- Restores `is_coming_soon()` and gates `/`, `/blog/`, `/about/` — reads `SITE_COMING_SOON` env var (already set to `true` in GitHub variables)
- Removes `on: push: master` trigger from deploy workflow — deploys are manual-only via `make deploy`