### PR TITLE
fix(coming-soon): show Toucan Studios OÜ as brand name

### DIFF
--- a/templates/coming-soon-launch.html
+++ b/templates/coming-soon-launch.html
@@ -177,14 +177,14 @@
 </head>
 <body>
     <main>
-        <p class="brand">{{ config.name }}</p>
+        <p class="brand">{{ config.brand_legal_name }}</p>
         <h1>Production Technology Specialist · Pipeline TD · VFX</h1>
         <p class="lede">CV and portfolio site launching soon. Production technology, pipeline support, and render operations across animation, VFX, and games.</p>
 
         <div class="launch-badge">Launching <strong>{{ launch_display }}</strong></div>
 
         <footer>
-            <span>&copy; {{ current_year }} {{ config.name }}</span>
+            <span>&copy; {{ current_year }} {{ config.brand_legal_name }}</span>
             <a href="mailto:{{ config.email }}">{{ config.email }}</a>
         </footer>
     </main>


### PR DESCRIPTION
## Summary
- Brand line and footer copyright now show `Toucan Studios OÜ` (`config.brand_legal_name`) instead of `Sreyeesh Garimella`
- No other changes

## Part of
Epic #221

## Test plan
- [x] `make test` passes (19/19)