### PR TITLE
fix(coming-soon): remove empty space and fix footer visibility

### DIFF
--- a/static/css/coming-soon.css
+++ b/static/css/coming-soon.css
@@ -48,9 +48,9 @@ a:focus-visible {
     max-width: 1100px;
     margin: 0 auto;
     padding: 2.5rem 2rem 2rem;
-    min-height: 100vh;
     display: flex;
     flex-direction: column;
+    gap: 5rem;
 }
 
 /* ── Header ──────────────────────────────────────── */
@@ -59,7 +59,6 @@ a:focus-visible {
     display: flex;
     align-items: center;
     gap: 1.5rem;
-    margin-bottom: 5rem;
 }
 
 .cs-brand {
@@ -91,7 +90,6 @@ a:focus-visible {
 /* ── Two-column grid ─────────────────────────────── */
 
 .cs-grid {
-    flex: 1;
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 4rem;
@@ -219,7 +217,6 @@ h1 {
 /* ── Footer ──────────────────────────────────────── */
 
 .cs-footer {
-    margin-top: 4rem;
     padding-top: 1.5rem;
     border-top: 1px solid var(--cs-border);
     text-align: right;
@@ -232,10 +229,7 @@ h1 {
 @media (max-width: 680px) {
     .cs-wrap {
         padding: 1.75rem 1.25rem 1.5rem;
-    }
-
-    .cs-header {
-        margin-bottom: 3rem;
+        gap: 3rem;
     }
 
     .cs-grid {

--- a/templates/coming-soon-launch.html
+++ b/templates/coming-soon-launch.html
@@ -99,7 +99,7 @@
             </aside>
         </main>
 
-        <footer class="cs-footer" data-reveal data-reveal-delay="500">
+        <footer class="cs-footer">
             <span>&copy; {{ current_year }} {{ config.brand_legal_name }}</span>
         </footer>
 


### PR DESCRIPTION
## Summary

Two layout bugs in the live deploy:

1. **Footer invisible** — the footer had `data-reveal` which starts it at `opacity: 0`. On a full-viewport-height page the footer sits at the very bottom, inside the IntersectionObserver's `-8%` rootMargin dead zone, so `.is-visible` never gets added. Fix: remove `data-reveal` from the footer so it renders immediately.

2. **Large empty space below content** — `.cs-grid` had `flex: 1` which expanded it to fill all remaining space inside a `min-height: 100vh` wrapper, creating a big blank area below the visible content. Fix: remove `flex: 1` from the grid and switch `.cs-wrap` to use `gap: 5rem` (3rem on mobile) for spacing, removing the separate header `margin-bottom` and footer `margin-top`.

## Test plan

- [ ] `make test` passes
- [ ] Page content sits naturally without large empty space below
- [ ] Footer copyright is visible
- [ ] Scroll reveal still works on h1, tags, bio, contacts, launch panel