### PR TITLE
fix(deploy): pass GitHub and LinkedIn URLs to deploy workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -21,6 +21,8 @@ jobs:
       BASE_PATH: ${{ vars.BASE_PATH }}
       GITHUB_PAGES_BASE_PATH: ${{ vars.BASE_PATH }}
       SITE_COMING_SOON: ${{ vars.SITE_COMING_SOON }}
+      SITE_GITHUB_URL: ${{ vars.SITE_GITHUB_URL }}
+      SITE_LINKEDIN_URL: ${{ vars.SITE_LINKEDIN_URL }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Adds `SITE_GITHUB_URL` and `SITE_LINKEDIN_URL` to `deploy-pages.yml`
- Fixes #233 — social icons missing on live coming-soon page