### PR TITLE
fix(coming-soon): professionalize launch page copy

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,14 +15,16 @@ SITE_CONFIG = {
     'name': os.getenv('SITE_NAME', 'Sreyeesh Garimella'),
     'brand_name': os.getenv('SITE_BRAND_NAME', 'Toucan Studios'),
     'brand_legal_name': os.getenv('SITE_BRAND_LEGAL_NAME', 'Toucan Studios OÜ'),
-    'tagline': os.getenv('SITE_TAGLINE', 'Toucan Studios · 1:1 Game Dev Mentoring'),
+    'tagline': os.getenv(
+        'SITE_TAGLINE',
+        'Pipeline TD · Production Tech Portfolio',
+    ),
     'email': os.getenv('SITE_EMAIL', 'toucan.sg@gmail.com'),
     'site_url': os.getenv('SITE_URL', '').rstrip('/'),
     'meta_description': os.getenv(
         'SITE_META_DESCRIPTION',
-        '1:1 game development mentoring at Toucan Studios. '
-        'For complete beginners, hobbyists, and indie teams. '
-        '60-minute video sessions, €75 each.',
+        'Portfolio and CV for Sreyeesh Garimella, focused on pipeline '
+        'technical direction, render operations, and production tooling.',
     ),
     'asset_version': os.getenv('ASSET_VERSION', '1'),
     'plausible_script_url': os.getenv('PLAUSIBLE_SCRIPT_URL', ''),

--- a/static/css/coming-soon.css
+++ b/static/css/coming-soon.css
@@ -5,9 +5,11 @@
 :root {
     --cs-bg:          #0d1117;
     --cs-surface:     #161b22;
+    --cs-surface-2:   #11161d;
     --cs-border:      rgba(255, 255, 255, 0.08);
     --cs-text:        #e6edf3;
     --cs-muted:       #7d8590;
+    --cs-soft:        #9aa4af;
     --cs-accent:      #2dd4bf;
     --cs-accent-dim:  rgba(45, 212, 191, 0.12);
     --cs-font-head:   'Sora', system-ui, sans-serif;
@@ -17,9 +19,11 @@
 [data-theme="light"] {
     --cs-bg:         #f6f8fa;
     --cs-surface:    #ffffff;
+    --cs-surface-2:  #f1f5f9;
     --cs-border:     rgba(0, 0, 0, 0.08);
     --cs-text:       #1c2128;
     --cs-muted:      #57606a;
+    --cs-soft:       #6e7781;
     --cs-accent:     #0d9488;
     --cs-accent-dim: rgba(13, 148, 136, 0.1);
 }
@@ -36,6 +40,9 @@ body {
     font-family: var(--cs-font-body);
     background: var(--cs-bg);
     min-height: 100vh;
+    background-image:
+        radial-gradient(circle at top left, rgba(45, 212, 191, 0.08), transparent 28rem),
+        radial-gradient(circle at bottom right, rgba(45, 212, 191, 0.05), transparent 24rem);
 }
 
 a {
@@ -108,7 +115,7 @@ a:focus-visible {
     justify-content: center;
     width: 32px;
     height: 32px;
-    background: none;
+    background: color-mix(in srgb, var(--cs-surface) 88%, transparent);
     border: 1px solid var(--cs-border);
     border-radius: 6px;
     color: var(--cs-muted);
@@ -134,8 +141,8 @@ a:focus-visible {
 .cs-main {
     display: flex;
     flex-direction: column;
-    gap: 2rem;
-    padding-top: 6rem;
+    gap: 1.35rem;
+    padding-top: 5rem;
 }
 
 /* ── Eyebrow badge ───────────────────────────────── */
@@ -178,9 +185,34 @@ a:focus-visible {
 /* ── Subtext ─────────────────────────────────────── */
 
 .cs-subtext {
-    font-size: 1rem;
-    line-height: 1.7;
+    font-size: 1.03rem;
+    line-height: 1.75;
     color: var(--cs-muted);
+    max-width: 44ch;
+}
+
+.cs-trust {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.cs-trust-item {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.45rem 0.8rem;
+    border: 1px solid var(--cs-border);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--cs-surface) 86%, transparent);
+    color: var(--cs-text);
+    font-size: 0.8rem;
+    letter-spacing: 0.04em;
+}
+
+.cs-signup-copy {
+    font-size: 0.95rem;
+    line-height: 1.7;
+    color: var(--cs-soft);
     max-width: 52ch;
 }
 
@@ -190,36 +222,41 @@ a:focus-visible {
     width: 100%;
 }
 
+.cs-form-card {
+    padding: 1.1rem 1.1rem 0.65rem;
+    border: 1px solid var(--cs-border);
+    border-radius: 18px;
+    background:
+        linear-gradient(
+            180deg,
+            color-mix(in srgb, var(--cs-surface) 94%, transparent),
+            color-mix(in srgb, var(--cs-surface-2) 96%, transparent)
+        );
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.16);
+}
+
+.cs-form-copy {
+    margin-bottom: 0.9rem;
+}
+
+.cs-form-copy h2 {
+    font-family: var(--cs-font-head);
+    font-size: 1.05rem;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    color: var(--cs-text);
+}
+
+.cs-form-copy p {
+    margin-top: 0.35rem;
+    font-size: 0.9rem;
+    color: var(--cs-muted);
+}
+
 .cs-form iframe {
     display: block;
     max-width: 100%;
 }
-
-/* ── Social links ────────────────────────────────── */
-
-.cs-links {
-    list-style: none;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1.25rem;
-}
-
-.cs-social-link {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    font-size: 0.85rem;
-    color: var(--cs-muted);
-    transition: color 0.15s;
-}
-
-.cs-social-link svg {
-    width: 16px;
-    height: 16px;
-    flex-shrink: 0;
-}
-
-.cs-social-link:hover { color: var(--cs-accent); }
 
 /* ── Footer ──────────────────────────────────────── */
 
@@ -262,6 +299,20 @@ a:focus-visible {
         gap: 2rem;
     }
 
+    .cs-main {
+        padding-top: 2.5rem;
+    }
+
+    .cs-form-card {
+        padding: 1rem 1rem 0.6rem;
+        border-radius: 16px;
+    }
+
+    .cs-footer {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
     .cs-header-link {
         display: none;
     }
@@ -278,8 +329,8 @@ a:focus-visible {
 .cs-eyebrow  { animation: cs-fade-up 0.45s ease both; animation-delay: 0.1s; }
 .cs-headline { animation: cs-fade-up 0.5s ease both;  animation-delay: 0.15s; }
 .cs-subtext  { animation: cs-fade-up 0.5s ease both;  animation-delay: 0.2s; }
-.cs-form     { animation: cs-fade-up 0.5s ease both;  animation-delay: 0.25s; }
-.cs-links    { animation: cs-fade-up 0.5s ease both;  animation-delay: 0.3s; }
+.cs-trust    { animation: cs-fade-up 0.5s ease both;  animation-delay: 0.25s; }
+.cs-form     { animation: cs-fade-up 0.55s ease both; animation-delay: 0.3s; }
 .cs-footer   { animation: cs-fade-up 0.45s ease both; animation-delay: 0.35s; }
 
 /* ── Reduced motion ──────────────────────────────── */

--- a/templates/coming-soon-launch.html
+++ b/templates/coming-soon-launch.html
@@ -48,25 +48,49 @@
         </header>
 
         <main class="cs-main">
-
             <div class="cs-eyebrow">
                 <span class="cs-badge">Coming {{ launch_display }}</span>
             </div>
 
             <h1 class="cs-headline">
-                Production Tech<br>
-                <em>Portfolio &amp; CV</em>
+                Pipeline TD &amp;<br>
+                <em>Production Tech Portfolio</em>
             </h1>
 
             <p class="cs-subtext">
-                Pipeline TD · Render Operations · VFX &amp; Games.<br>
-                Drop your email — I'll let you know when it's live.
+                Technical direction, render operations, pipeline tooling, and
+                production support across VFX and games.
+            </p>
+
+            <div class="cs-trust" aria-label="Professional focus">
+                <span class="cs-trust-item">Pipeline TD</span>
+                <span class="cs-trust-item">Render Operations</span>
+                <span class="cs-trust-item">VFX &amp; Games</span>
+            </div>
+
+            <p class="cs-signup-copy">
+                Leave your email and I&apos;ll let you know when the full site is
+                live.
             </p>
 
             <div class="cs-form">
-                <iframe data-tally-src="https://tally.so/embed/A749Zk?alignLeft=1&hideTitle=1&transparentBackground=1&dynamicHeight=1" loading="lazy" width="100%" height="120" frameborder="0" marginheight="0" marginwidth="0" title="Notify me when the site launches"></iframe>
+                <div class="cs-form-card">
+                    <div class="cs-form-copy">
+                        <h2>Get launch updates</h2>
+                        <p>Occasional updates only. No spam.</p>
+                    </div>
+                    <iframe
+                        data-tally-src="https://tally.so/embed/A749Zk?alignLeft=1&hideTitle=1&transparentBackground=1&dynamicHeight=1"
+                        loading="lazy"
+                        width="100%"
+                        height="120"
+                        frameborder="0"
+                        marginheight="0"
+                        marginwidth="0"
+                        title="Notify me when the site launches"
+                    ></iframe>
+                </div>
             </div>
-
 
         </main>
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -13,7 +13,10 @@ def test_home_page_content(client, monkeypatch):
     monkeypatch.setenv('SITE_COMING_SOON', 'true')
     response = client.get('/')
     assert b'Sreyeesh Garimella' in response.data
-    assert b'Production Tech' in response.data
+    assert b'Pipeline TD' in response.data
+    assert b'Production Tech Portfolio' in response.data
+    assert b'Render Operations' in response.data
+    assert b'1:1 game development mentoring' not in response.data
 
 
 def test_home_page_has_og_image(client):


### PR DESCRIPTION
## Summary
- Reposition the coming-soon page around Pipeline TD / production tech portfolio work
- Update default tagline and meta description away from mentoring copy
- Add regression coverage for the new coming-soon content

## Verification
- make test
- docker compose run --rm tests flake8 app.py tests/test_app.py
- git diff --check