### PR TITLE
fix(freeze): require site URL for static builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
 
       - name: Build static site
         env:
+          SITE_URL: ${{ vars.SITE_URL }}
+          BASE_PATH: ${{ vars.BASE_PATH }}
+          GITHUB_PAGES_BASE_PATH: ${{ vars.BASE_PATH }}
           SITE_COMING_SOON: ${{ vars.SITE_COMING_SOON }}
         run: |
           set -euo pipefail

--- a/freeze.py
+++ b/freeze.py
@@ -2,11 +2,21 @@ import os
 import shutil
 from pathlib import Path
 
-from app import app
+from app import SITE_CONFIG, app
 from blog import load_posts
 
 
 BUILD_DIR = Path('build')
+
+
+def require_site_url_for_static_build() -> None:
+    if SITE_CONFIG['site_url']:
+        return
+    raise SystemExit(
+        'ERROR: SITE_URL is not set. Canonical URLs in the static build '
+        'would point to localhost. Set SITE_URL to the deployed origin '
+        'before running freeze.py.'
+    )
 
 
 def write_file(destination: Path, content: str) -> None:
@@ -15,6 +25,8 @@ def write_file(destination: Path, content: str) -> None:
 
 
 def build_static_site() -> None:
+    require_site_url_for_static_build()
+
     base_path = os.getenv('GITHUB_PAGES_BASE_PATH', '')
     normalized_base_path = base_path.strip()
     if normalized_base_path and not normalized_base_path.startswith('/'):

--- a/tests/test_freeze_utils.py
+++ b/tests/test_freeze_utils.py
@@ -1,4 +1,7 @@
+import pytest
+
 from blog import strip_leading_metadata_lines
+from freeze import SITE_CONFIG, require_site_url_for_static_build
 
 
 def test_strip_leading_metadata_removes_metadata_block():
@@ -17,3 +20,16 @@ def test_strip_leading_metadata_leaves_normal_text():
     content = "First line\nSecond line"
     cleaned = strip_leading_metadata_lines(content)
     assert cleaned == content
+
+
+def test_static_build_requires_site_url(monkeypatch):
+    monkeypatch.setitem(SITE_CONFIG, 'site_url', '')
+
+    with pytest.raises(SystemExit, match='SITE_URL is not set'):
+        require_site_url_for_static_build()
+
+
+def test_static_build_allows_configured_site_url(monkeypatch):
+    monkeypatch.setitem(SITE_CONFIG, 'site_url', 'https://example.com')
+
+    require_site_url_for_static_build()


### PR DESCRIPTION
## Summary
- Fail static builds when SITE_URL is missing so frozen canonical URLs cannot fall back to localhost
- Pass SITE_URL and BASE_PATH variables into the CI freeze step
- Add unit coverage for the static-build SITE_URL guard

Closes #167

## Verification
- make test
- docker compose run --rm tests flake8 freeze.py tests/test_freeze_utils.py
- git diff --check