### PR TITLE
feat(cv): build first-pass CV homepage

### DIFF
--- a/app.py
+++ b/app.py
@@ -291,7 +291,7 @@ CV_PAGE = {
 def home():
     return render_template(
         'landing.html',
-        **build_page_context(page_slug='home'),
+        **build_page_context(page_slug='home', main_class='cv-page-main'),
         cv=CV_PAGE,
     )
 

--- a/app.py
+++ b/app.py
@@ -174,21 +174,7 @@ CV_PAGE = {
                 'Coordinated with artists and production to resolve issues.',
             ],
         },
-        {
-            'role': 'Assistant Technical Director',
-            'company': 'Walt Disney Animation Studios',
-            'period': 'Jul 2019 - Aug 2019',
-            'location': 'Burbank, CA',
-            'summary': (
-                'Pipeline workflow, DCC troubleshooting, and technical '
-                'production systems support.'
-            ),
-            'highlights': [
-                'Supported technical production systems across shot and asset '
-                'work.',
-                'Helped troubleshoot DCC and pipeline workflow issues.',
-            ],
-        },
+
         {
             'role': 'Pipeline TD',
             'company': 'Encore VFX',
@@ -226,7 +212,7 @@ CV_PAGE = {
     'credits': [
         'Blizzard Entertainment',
         'DNEG Animation',
-        'Walt Disney Animation Studios',
+
         'Boulder Media',
         'GameCityKajaani',
     ],

--- a/app.py
+++ b/app.py
@@ -17,21 +17,26 @@ SITE_CONFIG = {
     'brand_legal_name': os.getenv('SITE_BRAND_LEGAL_NAME', 'Toucan Studios OÜ'),
     'tagline': os.getenv(
         'SITE_TAGLINE',
-        'Pipeline TD · Production Tech Portfolio',
+        'Pipeline TD and Software Developer',
     ),
-    'email': os.getenv('SITE_EMAIL', 'toucan.sg@gmail.com'),
+    'email': os.getenv('SITE_EMAIL', 'sgarime1@gmail.com'),
+    'phone': os.getenv('SITE_PHONE', '+372 5827 7155'),
     'site_url': os.getenv('SITE_URL', '').rstrip('/'),
     'meta_description': os.getenv(
         'SITE_META_DESCRIPTION',
-        'Portfolio and CV for Sreyeesh Garimella, focused on pipeline '
-        'technical direction, render operations, and production tooling.',
+        'CV and portfolio for Sreyeesh Garimella: Python tooling, workflow '
+        'automation, and production technology for animation, games, and beyond.',
     ),
     'asset_version': os.getenv('ASSET_VERSION', '1'),
     'plausible_script_url': os.getenv('PLAUSIBLE_SCRIPT_URL', ''),
     'plausible_domain': os.getenv('PLAUSIBLE_DOMAIN', ''),
     'social_image': os.getenv('SITE_SOCIAL_IMAGE', 'images/SreyeeshProfilePic.jpg'),
     'github_url': os.getenv('SITE_GITHUB_URL', ''),
-    'linkedin_url': os.getenv('SITE_LINKEDIN_URL', ''),
+    'linkedin_url': os.getenv(
+        'SITE_LINKEDIN_URL',
+        'https://www.linkedin.com/in/sreyeeshgarimella',
+    ),
+    'imdb_url': os.getenv('SITE_IMDB_URL', ''),
     'location': os.getenv('SITE_LOCATION', 'Estonia'),
     'launch_date': os.getenv('SITE_LAUNCH_DATE', '2026-05-31'),
 }
@@ -53,23 +58,6 @@ def get_posts():
     if 'posts' not in g:
         g.posts = load_posts()
     return g.posts
-
-
-def is_coming_soon() -> bool:
-    return os.getenv('SITE_COMING_SOON', 'false').lower() == 'true'
-
-
-def coming_soon_response():
-    from datetime import date
-    launch = datetime.strptime(SITE_CONFIG['launch_date'], '%Y-%m-%d')
-    return render_template(
-        'coming-soon-launch.html',
-        config=SITE_CONFIG,
-        canonical_url=build_absolute_url(request.path),
-        current_year=date.today().year,
-        launch_display=launch.strftime('%B %-d, %Y'),
-        launch_iso=SITE_CONFIG['launch_date'],
-    )
 
 
 def build_absolute_url(path: str) -> str:
@@ -101,104 +89,215 @@ def build_page_context(**extra) -> dict:
     return context
 
 
-MENTORING_BOOKING_URL = os.getenv(
-    'MENTORING_BOOKING_URL',
-    'https://cal.com/sreyeesh-dhb2sk/60min',
-)
-
-LANDING_PAGE = {
-    'page_title': 'Game Dev Mentoring',
-    'eyebrow': '1:1 Game Dev Mentoring',
-    'headline': 'Personal guidance for making your first (or next) game.',
-    'lede': (
-        'For complete beginners, hobbyists, and small indie teams. '
-        'No experience required. Bring a question, an idea, or a project '
-        'you are stuck on, and leave with a concrete next step.'
+CV_PAGE = {
+    'page_title': 'CV and Portfolio',
+    'eyebrow': 'CV / Portfolio',
+    'headline': 'Pipeline TD and software developer for production technology.',
+    'tagline': (
+        'Python tooling, workflow automation, and technical mentoring for '
+        'animation, games, and beyond.'
     ),
-    'cta_label': 'Book a session',
-    'cta_meta': '€75 · 60 min · 1:1 video call',
-    'cta_meta_short': '€75 · 60 min',
-    'trust': (
-        'Currently mentoring at GameCityKajaani · '
-        'Blizzard Entertainment alumni'
+    'summary': (
+        'Pipeline TD with VFX and feature animation studio experience in '
+        'Python tool development, Linux, and DCC pipelines including Maya, '
+        'Katana, Houdini, and Nuke. Experienced in sprint-based development, '
+        'code reviews, stakeholder documentation, and mentoring Assistant TDs.'
     ),
-    'audience_label': "Who it's for",
-    'audience_heading': 'This is for you if…',
-    'audience': [
-        "You've never made a game and want to start.",
-        "You're picking your first engine and feel overwhelmed "
-        "by the options.",
-        "You're working on a personal project and want someone "
-        "to think it through with.",
-        "You're on a small indie team and want a senior perspective.",
+    'fit': [
+        'Pipeline TD / production technology roles',
+        'Python tooling and workflow automation',
+        'Internal tools, workflow automation, and support engineering',
+        'Creative technology for animation, VFX, and games',
     ],
-    'topics_label': 'What I cover',
-    'topics': [
-        'Getting started: picking an engine and scoping a first project',
-        'Game design fundamentals and turning an idea into '
-        'something playable',
-        'Working through the hard parts: motivation, scope, and finishing',
-    ],
-    'steps_label': 'How it works',
-    'steps': [
-        'Book a 60-minute session and tell me what you are working on.',
-        'I meet with you 1:1 over video.',
-        'You leave with a concrete next step.',
-    ],
-    'about_label': 'About',
-    'about_body': (
-        "I'm a Blizzard Entertainment alumni and currently mentor aspiring "
-        "game developers at GameCityKajaani. I help people find their footing "
-        "in game dev, whatever stage they are starting from."
-    ),
-    'faq_label': 'FAQ',
-    'faq': [
+    'experience': [
         {
-            'q': "I'm a complete beginner. Is this for me?",
-            'a': 'Yes. Most of the people I work with are just starting out. '
-                 'I help with choosing an engine, scoping a first project, '
-                 'and getting unstuck.',
+            'role': 'Technical Mentor and Production Workflow Specialist',
+            'company': 'Toucan Studios OÜ',
+            'period': 'Jun 2023 - present',
+            'location': 'Estonia',
+            'summary': (
+                'Technical mentoring and production workflow support for '
+                'junior developers and creative technology learners.'
+            ),
+            'highlights': [
+                'Mentored junior developers on Python, Git, pipeline standards, '
+                'and technical problem-solving.',
+                'Delivered formal tutorials and documentation to support team '
+                'growth.',
+                'Led sprint-style development cycles and tracked tasks to '
+                'deliver tooling on schedule.',
+            ],
         },
         {
-            'q': 'Which engine do you teach?',
-            'a': "I'm engine-agnostic. Whether you're using Godot, Unity, "
-                 "Unreal, or something else, bring it along and we'll work "
-                 "with what you have.",
+            'role': 'Lighting TD / Pipeline Support',
+            'company': 'DNEG',
+            'period': '2022 - 2023',
+            'location': 'Remote',
+            'summary': (
+                'Python tooling and production support for Maya, Katana, USD '
+                'shot workflows, RenderMan, and ShotGrid pipeline work.'
+            ),
+            'highlights': [
+                'Built Python tooling in Maya and Katana supporting USD shot '
+                'workflows and RenderMan rendering.',
+                'Collaborated with R&D and creative supervisors on show-specific '
+                'tool development.',
+                'Gathered and actioned stakeholder feedback on pipeline tasks.',
+                'Provided face-to-face technical support to artists and bridged '
+                'technical and non-technical teams.',
+            ],
         },
         {
-            'q': 'How long is a session?',
-            'a': '60 minutes, 1:1, over video. €75 per session.',
+            'role': 'Production Show Technician - In-Game Cinematics',
+            'company': 'Blizzard Entertainment',
+            'period': 'May 2021 - Nov 2021',
+            'location': 'Remote',
+            'summary': (
+                'Lighting, rendering, and publishing workflow support for '
+                'in-game cinematics production.'
+            ),
+            'highlights': [
+                'Developed Python and Lua tools integrated with ShotGrid.',
+                'Supported lighting, rendering, and publishing workflows.',
+                'Mentored artists on workflow issues and supported technical '
+                'handoffs between TDs and production.',
+            ],
         },
         {
-            'q': 'Can I book more than one?',
-            'a': "Yes. Most people book a single session first, see if it's "
-                 'useful, and come back when they hit the next wall.',
+            'role': 'Render Wrangler',
+            'company': 'Boulder Media',
+            'period': 'Nov 2019 - Jan 2021',
+            'location': 'Dublin, Ireland',
+            'summary': 'Render farm operations and production continuity.',
+            'highlights': [
+                'Managed render farm operations under tight deadlines.',
+                'Coordinated with artists and production to resolve issues.',
+            ],
+        },
+        {
+            'role': 'Assistant Technical Director',
+            'company': 'Walt Disney Animation Studios',
+            'period': 'Jul 2019 - Aug 2019',
+            'location': 'Burbank, CA',
+            'summary': (
+                'Pipeline workflow, DCC troubleshooting, and technical '
+                'production systems support.'
+            ),
+            'highlights': [
+                'Supported technical production systems across shot and asset '
+                'work.',
+                'Helped troubleshoot DCC and pipeline workflow issues.',
+            ],
+        },
+        {
+            'role': 'Pipeline TD',
+            'company': 'Encore VFX',
+            'period': 'Dec 2018 - Feb 2019',
+            'location': 'Burbank, CA',
+            'summary': 'Pipeline and technical operations support for VFX work.',
+            'highlights': [
+                'Supported pipeline and technical operations on VFX productions.',
+                'Resolved DCC and workflow issues for artists.',
+            ],
+        },
+        {
+            'role': 'Render Wrangler',
+            'company': 'FuseFX',
+            'period': 'Aug 2018 - Dec 2018',
+            'location': 'Los Angeles, CA',
+            'summary': 'Render farm support across VFX productions.',
+            'highlights': [
+                'Diagnosed rendering failures.',
+                'Maintained production render pipelines.',
+            ],
+        },
+        {
+            'role': 'Render Wrangler',
+            'company': 'CoSA VFX',
+            'period': 'Dec 2016 - Aug 2018',
+            'location': 'Los Angeles, CA',
+            'summary': 'Render farm management for VFX productions.',
+            'highlights': [
+                'Delivered two years of render farm management.',
+                'Supported V-Ray and Redshift rendering workflows.',
+            ],
         },
     ],
-    'closing_heading': 'Ready when you are.',
-    'closing_body': (
-        'Book a 60-minute session and come with whatever you are '
-        'working on or thinking about.'
+    'credits': [
+        'Blizzard Entertainment',
+        'DNEG Animation',
+        'Walt Disney Animation Studios',
+        'Boulder Media',
+        'GameCityKajaani',
+    ],
+    'skills': [
+        {
+            'group': 'Languages and systems',
+            'items': ['Python', 'Linux', 'Lua', 'Git', 'Sprint development'],
+        },
+        {
+            'group': 'DCC and pipeline',
+            'items': [
+                'Maya',
+                'Houdini',
+                'Katana',
+                'Nuke',
+                'ShotGrid / Flow',
+            ],
+        },
+        {
+            'group': 'Rendering and data',
+            'items': ['USD / Alembic', 'RenderMan', 'Deadline', 'V-Ray', 'Redshift'],
+        },
+        {
+            'group': 'Production practice',
+            'items': [
+                'Tool development',
+                'Code review',
+                'Pipeline workflows',
+                'Mentoring',
+                'Documentation',
+            ],
+        },
+    ],
+    'education': [
+        {
+            'school': 'California State University, Northridge',
+            'credential': 'Art & Animation',
+            'period': '2010 - 2012',
+        },
+        {
+            'school': 'College of the Canyons',
+            'credential': 'Associate of Arts, Animation',
+            'period': '2007 - 2010',
+        },
+        {
+            'school': 'iAnimate.net',
+            'credential': 'Character Animation',
+            'period': '2013',
+        },
+    ],
+    'links_heading': 'Links',
+    'contact_heading': 'Available for production technology work',
+    'contact_body': (
+        'I am open to industry and adjacent technical roles involving Python, '
+        'workflow automation, production support, internal tools, or technical '
+        'mentoring.'
     ),
 }
 
 
 @app.route('/')
 def home():
-    if is_coming_soon():
-        return coming_soon_response()
     return render_template(
         'landing.html',
         **build_page_context(page_slug='home'),
-        booking_url=MENTORING_BOOKING_URL,
-        landing=LANDING_PAGE,
+        cv=CV_PAGE,
     )
 
 
 @app.route('/blog/')
 def blog_index():
-    if is_coming_soon():
-        return coming_soon_response()
     return render_template(
         'blog/list.html',
         **build_page_context(page_slug='blog', posts=get_posts()),
@@ -226,8 +325,6 @@ def blog_detail(slug: str):
 
 @app.route('/about/')
 def about():
-    if is_coming_soon():
-        return coming_soon_response()
     return render_template(
         'about.html',
         **build_page_context(page_slug='about'),

--- a/app.py
+++ b/app.py
@@ -19,7 +19,7 @@ SITE_CONFIG = {
         'SITE_TAGLINE',
         'Pipeline TD and Software Developer',
     ),
-    'email': os.getenv('SITE_EMAIL', 'sgarime1@gmail.com'),
+    'email': os.getenv('SITE_EMAIL', 'toucan.sg@gmail.com'),
     'phone': os.getenv('SITE_PHONE', '+372 5827 7155'),
     'site_url': os.getenv('SITE_URL', '').rstrip('/'),
     'meta_description': os.getenv(

--- a/app.py
+++ b/app.py
@@ -174,7 +174,21 @@ CV_PAGE = {
                 'Coordinated with artists and production to resolve issues.',
             ],
         },
-
+        {
+            'role': 'Assistant Technical Director',
+            'company': 'Walt Disney Animation Studios',
+            'period': 'Jul 2019 - Aug 2019',
+            'location': 'Burbank, CA',
+            'summary': (
+                'Pipeline workflow, DCC troubleshooting, and technical '
+                'production systems support.'
+            ),
+            'highlights': [
+                'Supported technical production systems across shot and asset '
+                'work.',
+                'Helped troubleshoot DCC and pipeline workflow issues.',
+            ],
+        },
         {
             'role': 'Pipeline TD',
             'company': 'Encore VFX',
@@ -212,6 +226,7 @@ CV_PAGE = {
     'credits': [
         'Blizzard Entertainment',
         'DNEG Animation',
+        'Walt Disney Animation Studios',
 
         'Boulder Media',
         'GameCityKajaani',

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -186,6 +186,24 @@ code, pre {
 .nav-links .nav-link--cta { all: unset; font-family: system-ui, -apple-system, sans-serif; font-size: 0.875rem; color: var(--text-muted); cursor: pointer; }
 .nav-links .nav-link--cta:hover { color: var(--text); }
 
+.nav-section-divider {
+    display: inline-block;
+    width: 1px;
+    height: 14px;
+    background: var(--border);
+    margin: 0 0.1rem;
+    flex-shrink: 0;
+    align-self: center;
+}
+
+.nav-section-link {
+    font-family: var(--font-mono) !important;
+    font-size: 0.7rem !important;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+
 /* Dark mode toggle */
 .nav-controls { display: flex; align-items: center; }
 

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -138,37 +138,35 @@
 /* ── Main content ────────────────────────── */
 
 .cv-main {
-    padding: 3.5rem 3.5rem 6rem;
-    max-width: 780px;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 2rem 2rem 3rem;
+    max-width: 820px;
 }
 
-/* ── Sections ────────────────────────────── */
+/* ── Sections (boxes) ────────────────────── */
 
 .cv-section {
-    padding-bottom: 3.5rem;
-    margin-bottom: 3.5rem;
-    border-bottom: 1px solid var(--border);
-}
-
-.cv-contact {
-    border-bottom: none;
-    margin-bottom: 0;
-    padding-bottom: 0;
+    padding: 2rem;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: var(--cv-surface);
 }
 
 .section-heading {
-    margin-bottom: 2rem;
+    margin-bottom: 1.5rem;
     color: var(--text);
-    font-size: clamp(1.4rem, 2.5vw, 1.9rem);
+    font-size: clamp(1.1rem, 2vw, 1.35rem);
     font-weight: 700;
-    letter-spacing: -0.03em;
-    line-height: 1.1;
+    letter-spacing: -0.02em;
+    line-height: 1.15;
 }
 
 /* ── Intro ───────────────────────────────── */
 
 .cv-intro {
-    padding-top: 0.25rem;
+    padding-top: 0;
 }
 
 .eyebrow {
@@ -215,41 +213,20 @@
     line-height: 1.4;
 }
 
-/* ── Timeline ────────────────────────────── */
+/* ── Timeline (card-based) ───────────────── */
 
 .timeline {
-    position: relative;
-    padding-left: 1.5rem;
-}
-
-.timeline::before {
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 0.45rem;
-    bottom: 2rem;
-    width: 1px;
-    background: var(--border);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
 }
 
 .timeline-item {
-    position: relative;
-    padding-bottom: 2.5rem;
-}
-
-.timeline-item:last-child {
-    padding-bottom: 0;
-}
-
-.timeline-item::before {
-    content: '';
-    position: absolute;
-    left: calc(-1.5rem - 3px);
-    top: 0.45rem;
-    width: 7px;
-    height: 7px;
-    border-radius: 50%;
-    background: var(--accent);
+    padding: 1.25rem 1.25rem 1.25rem 1.5rem;
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--accent);
+    border-radius: 8px;
+    background: var(--bg);
 }
 
 .timeline-item__meta {
@@ -526,8 +503,13 @@
     }
 
     .cv-main {
-        padding: 2rem 1.5rem 5rem;
-        max-width: 100%;
+        padding: 1rem 1rem 3rem;
+        gap: 0.75rem;
+    }
+
+    .cv-section {
+        padding: 1.5rem;
+        border-radius: 10px;
     }
 }
 
@@ -543,27 +525,26 @@
     }
 
     .cv-main {
-        padding: 1.75rem 1.2rem 4rem;
+        padding: 0.75rem 0.75rem 3rem;
+        gap: 0.6rem;
+    }
+
+    .cv-section {
+        padding: 1.25rem;
+        border-radius: 8px;
     }
 
     .section-heading {
-        font-size: 1.3rem;
+        font-size: 1.1rem;
+        margin-bottom: 1rem;
     }
 
     .lede {
         font-size: 1.05rem;
     }
 
-    .timeline {
-        padding-left: 1.25rem;
-    }
-
-    .timeline::before {
-        bottom: 1.5rem;
-    }
-
-    .timeline-item::before {
-        left: calc(-1.25rem - 3px);
+    .timeline-item {
+        padding: 1rem 1rem 1rem 1.1rem;
     }
 
     .timeline-item__meta {

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -138,35 +138,37 @@
 /* ── Main content ────────────────────────── */
 
 .cv-main {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    padding: 2rem 2rem 3rem;
-    max-width: 820px;
+    padding: 3.5rem 3.5rem 6rem;
+    max-width: 780px;
 }
 
-/* ── Sections (boxes) ────────────────────── */
+/* ── Sections ────────────────────────────── */
 
 .cv-section {
-    padding: 2rem;
-    border: 1px solid var(--border);
-    border-radius: 12px;
-    background: var(--cv-surface);
+    padding-bottom: 3.5rem;
+    margin-bottom: 3.5rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.cv-contact {
+    border-bottom: none;
+    margin-bottom: 0;
+    padding-bottom: 0;
 }
 
 .section-heading {
-    margin-bottom: 1.5rem;
+    margin-bottom: 2rem;
     color: var(--text);
-    font-size: clamp(1.1rem, 2vw, 1.35rem);
+    font-size: clamp(1.4rem, 2.5vw, 1.9rem);
     font-weight: 700;
-    letter-spacing: -0.02em;
-    line-height: 1.15;
+    letter-spacing: -0.03em;
+    line-height: 1.1;
 }
 
 /* ── Intro ───────────────────────────────── */
 
 .cv-intro {
-    padding-top: 0;
+    padding-top: 0.25rem;
 }
 
 .eyebrow {
@@ -213,20 +215,41 @@
     line-height: 1.4;
 }
 
-/* ── Timeline (card-based) ───────────────── */
+/* ── Timeline ────────────────────────────── */
 
 .timeline {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
+    position: relative;
+    padding-left: 1.5rem;
+}
+
+.timeline::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0.45rem;
+    bottom: 2rem;
+    width: 1px;
+    background: var(--border);
 }
 
 .timeline-item {
-    padding: 1.25rem 1.25rem 1.25rem 1.5rem;
-    border: 1px solid var(--border);
-    border-left: 3px solid var(--accent);
-    border-radius: 8px;
-    background: var(--bg);
+    position: relative;
+    padding-bottom: 2.5rem;
+}
+
+.timeline-item:last-child {
+    padding-bottom: 0;
+}
+
+.timeline-item::before {
+    content: '';
+    position: absolute;
+    left: calc(-1.5rem - 3px);
+    top: 0.45rem;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--accent);
 }
 
 .timeline-item__meta {
@@ -503,13 +526,8 @@
     }
 
     .cv-main {
-        padding: 1rem 1rem 3rem;
-        gap: 0.75rem;
-    }
-
-    .cv-section {
-        padding: 1.5rem;
-        border-radius: 10px;
+        padding: 2rem 1.5rem 5rem;
+        max-width: 100%;
     }
 }
 
@@ -525,26 +543,27 @@
     }
 
     .cv-main {
-        padding: 0.75rem 0.75rem 3rem;
-        gap: 0.6rem;
-    }
-
-    .cv-section {
-        padding: 1.25rem;
-        border-radius: 8px;
+        padding: 1.75rem 1.2rem 4rem;
     }
 
     .section-heading {
-        font-size: 1.1rem;
-        margin-bottom: 1rem;
+        font-size: 1.3rem;
     }
 
     .lede {
         font-size: 1.05rem;
     }
 
-    .timeline-item {
-        padding: 1rem 1rem 1rem 1.1rem;
+    .timeline {
+        padding-left: 1.25rem;
+    }
+
+    .timeline::before {
+        bottom: 1.5rem;
+    }
+
+    .timeline-item::before {
+        left: calc(-1.25rem - 3px);
     }
 
     .timeline-item__meta {

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -91,6 +91,47 @@ html {
     display: block;
 }
 
+/* ── Availability badge ──────────────────── */
+
+.cv-availability {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin-top: 0.65rem;
+    padding: 0.3rem 0.75rem 0.3rem 0.55rem;
+    border-radius: 999px;
+    border: 1px solid rgba(34, 197, 94, 0.35);
+    background: rgba(34, 197, 94, 0.08);
+    color: #16a34a;
+    font-size: 0.72rem;
+    font-weight: 500;
+    letter-spacing: 0.03em;
+}
+
+[data-theme="dark"] .cv-availability {
+    color: #4ade80;
+    background: rgba(74, 222, 128, 0.08);
+    border-color: rgba(74, 222, 128, 0.25);
+}
+
+.cv-availability__dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: #16a34a;
+    flex-shrink: 0;
+    animation: pulse-dot 2.5s ease-in-out infinite;
+}
+
+[data-theme="dark"] .cv-availability__dot {
+    background: #4ade80;
+}
+
+@keyframes pulse-dot {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50%       { opacity: 0.5; transform: scale(0.75); }
+}
+
 .cv-social-link {
     display: inline-flex;
     align-items: center;

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -1,378 +1,281 @@
 @import url('base.css');
 
-/* ---------- Topbar ---------- */
-
-.topbar {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1.25rem 1.5rem;
-    max-width: 760px;
-    margin: 0 auto;
+:root {
+    --cv-surface: #ffffff;
 }
 
-.topbar-name {
-    font-family: var(--font-mono);
-    font-size: 0.75rem;
-    color: var(--text-muted);
-    letter-spacing: 0.02em;
+[data-theme="dark"] {
+    --cv-surface: #161616;
 }
-
-.theme-toggle {
-    background: none;
-    border: none;
-    padding: 0.25rem;
-    cursor: pointer;
-    color: var(--text-muted);
-    display: flex;
-    align-items: center;
-    transition: color 0.15s;
-}
-
-.theme-toggle:hover { color: var(--text); }
-.theme-toggle .sun-icon { display: none; }
-.theme-toggle .moon-icon { display: block; }
-[data-theme="dark"] .theme-toggle .sun-icon { display: block; }
-[data-theme="dark"] .theme-toggle .moon-icon { display: none; }
-
-/* ---------- Page shell ---------- */
 
 .page {
-    max-width: 760px;
+    max-width: 1040px;
     margin: 0 auto;
-    padding: 2rem 1.5rem 4rem;
+    padding: 3rem 1.5rem 5rem;
 }
 
-/* ---------- Shared section label ---------- */
+.cv-hero {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 320px;
+    gap: 3rem;
+    align-items: start;
+    padding: 4rem 0 3.5rem;
+    border-bottom: 1px solid var(--border);
+}
 
-.section-label,
-.eyebrow {
+.eyebrow,
+.section-kicker {
     display: inline-block;
+    margin-bottom: 1rem;
+    color: var(--accent);
     font-family: var(--font-mono);
-    font-size: 0.7rem;
+    font-size: 0.72rem;
     letter-spacing: 0.12em;
     text-transform: uppercase;
-    color: var(--text-muted);
+}
+
+.cv-hero h1 {
+    max-width: 11ch;
     margin-bottom: 1rem;
-}
-
-.eyebrow {
-    color: var(--accent);
-    margin-bottom: 1.5rem;
-}
-
-/* ---------- Hero ---------- */
-
-.hero {
-    padding: 3rem 0 4rem;
-    border-bottom: 1px solid var(--border);
-    margin-bottom: 3.5rem;
-}
-
-.hero h1 {
-    font-family: var(--font-sans);
-    font-weight: 700;
-    font-size: clamp(2.25rem, 6vw, 3.25rem);
-    line-height: 1.1;
-    letter-spacing: -0.03em;
-    margin-bottom: 1.5rem;
-    max-width: 22ch;
     color: var(--text);
+    font-size: clamp(3rem, 9vw, 6.5rem);
+    line-height: 0.95;
+    letter-spacing: -0.04em;
+}
+
+.cv-title {
+    margin-bottom: 1rem;
+    color: var(--text);
+    font-size: clamp(1.25rem, 3vw, 1.75rem);
+    font-weight: 600;
 }
 
 .lede {
-    font-size: 1.15rem;
+    max-width: 58ch;
+    margin-bottom: 1.25rem;
+    color: var(--text);
+    font-size: 1.2rem;
     line-height: 1.55;
-    color: var(--text-muted);
-    max-width: 60ch;
-    margin-bottom: 2rem;
 }
 
-/* ---------- CTA button ---------- */
+.cv-summary {
+    max-width: 68ch;
+    color: var(--text-muted);
+    font-size: 1rem;
+    line-height: 1.75;
+}
 
-.cta-row {
+.cv-actions {
     display: flex;
     flex-wrap: wrap;
+    gap: 0.85rem 1rem;
     align-items: center;
-    gap: 1rem 1.25rem;
-    margin-bottom: 1rem;
+    margin-top: 1.75rem;
+}
+
+.cv-actions a {
+    color: var(--text);
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    text-decoration: none;
+}
+
+.cv-actions a:not(.btn-primary) {
+    border-bottom: 1px solid var(--border);
+}
+
+.cv-actions a:hover {
+    color: var(--accent);
 }
 
 .btn-primary {
-    display: inline-block;
-    background: var(--text);
-    color: var(--bg);
-    padding: 0.85rem 1.5rem;
-    border-radius: 6px;
-    font-family: var(--font-sans);
-    font-size: 0.95rem;
-    font-weight: 500;
-    text-decoration: none;
-    transition: transform 0.1s ease, opacity 0.15s ease;
-}
-
-.btn-primary:hover {
-    opacity: 0.9;
-    transform: translateY(-1px);
-}
-
-.cta-meta {
-    font-family: var(--font-mono);
-    font-size: 0.78rem;
-    color: var(--text-muted);
-}
-
-.cta-meta a {
-    color: var(--text-muted);
-    text-decoration: underline;
-    text-underline-offset: 2px;
-}
-
-.cta-meta a:hover { color: var(--accent); }
-
-.trust {
-    font-family: var(--font-mono);
-    font-size: 0.75rem;
-    color: var(--text-muted);
-    margin-top: 1.5rem;
-}
-
-/* ---------- Generic section block ---------- */
-
-.block {
-    margin-bottom: 3.5rem;
-}
-
-.block > p {
-    font-size: 1rem;
-    line-height: 1.65;
-    color: var(--text-muted);
-    max-width: 62ch;
-}
-
-/* ---------- Block heading ---------- */
-
-.block-heading {
-    font-family: var(--font-sans);
-    font-weight: 600;
-    font-size: 1.5rem;
-    letter-spacing: -0.02em;
-    color: var(--text);
-    margin-bottom: 1.5rem;
-    max-width: 28ch;
-}
-
-/* ---------- Check list ("This is for you if...") ---------- */
-
-.check-list {
-    list-style: none;
-    display: flex;
-    flex-direction: column;
-    gap: 0.85rem;
-}
-
-.check-list li {
-    position: relative;
-    padding-left: 2rem;
-    font-size: 1rem;
-    line-height: 1.55;
-    color: var(--text);
-    max-width: 60ch;
-}
-
-.check-list li::before {
-    content: "";
-    position: absolute;
-    left: 0;
-    top: 0.55rem;
-    width: 0.9rem;
-    height: 0.9rem;
-    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%231a1a1a' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><polyline points='3 8.5 6.5 12 13 4.5'/></svg>");
-    background-repeat: no-repeat;
-    background-size: 100% 100%;
-}
-
-[data-theme="dark"] .check-list li::before {
-    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23d4d4d4' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><polyline points='3 8.5 6.5 12 13 4.5'/></svg>");
-}
-
-/* ---------- Topic list ("What I cover") ---------- */
-
-.topic-list {
-    list-style: none;
-    border-top: 1px solid var(--border);
-}
-
-.topic-list li {
-    font-size: 1rem;
-    line-height: 1.6;
-    color: var(--text);
-    padding: 1rem 0;
-    border-bottom: 1px solid var(--border);
-    display: flex;
-    gap: 1.25rem;
-    align-items: baseline;
-}
-
-.topic-list .idx {
-    font-family: var(--font-mono);
-    font-size: 0.7rem;
-    color: var(--accent);
-    flex-shrink: 0;
-    letter-spacing: 0.05em;
-}
-
-/* ---------- Steps ---------- */
-
-.steps-list {
-    list-style: none;
-}
-
-.steps-list li {
-    font-size: 1rem;
-    line-height: 1.6;
-    color: var(--text);
-    padding: 0.5rem 0;
-    display: flex;
-    gap: 1.25rem;
-    align-items: baseline;
-}
-
-.steps-list .idx {
-    font-family: var(--font-mono);
-    font-size: 0.7rem;
-    color: var(--accent);
-    flex-shrink: 0;
-    width: 1.5rem;
-    height: 1.5rem;
-    border: 1px solid var(--accent);
-    border-radius: 50%;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-}
-
-/* ---------- About ---------- */
-
-.about-block p {
-    font-family: var(--font-sans);
-    font-size: 1.05rem;
-    line-height: 1.65;
-    color: var(--text);
-    max-width: 62ch;
-}
-
-/* ---------- FAQ ---------- */
-
-.faq {
-    border-top: 1px solid var(--border);
-}
-
-.faq dt {
-    font-family: var(--font-sans);
+    min-height: 2.65rem;
+    padding: 0.75rem 1.15rem;
+    border-radius: 6px;
+    background: var(--text);
+    color: var(--bg) !important;
+    font-family: var(--font-sans) !important;
     font-weight: 600;
-    font-size: 1rem;
-    letter-spacing: -0.01em;
-    color: var(--text);
-    padding: 1.25rem 0 0.5rem;
 }
 
-.faq dd {
-    font-size: 0.95rem;
-    line-height: 1.6;
+.cv-snapshot {
+    padding: 1.25rem;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--cv-surface);
+}
+
+.cv-snapshot dl {
+    display: grid;
+    gap: 1.1rem;
+}
+
+.cv-snapshot dt,
+.experience-meta,
+.education-list span {
     color: var(--text-muted);
-    margin: 0 0 1.25rem;
-    padding-bottom: 1.25rem;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.cv-snapshot dd {
+    margin-top: 0.35rem;
+    color: var(--text);
+    line-height: 1.5;
+}
+
+.cv-section {
+    display: grid;
+    grid-template-columns: 220px minmax(0, 1fr);
+    gap: 2.5rem;
+    padding: 3rem 0;
     border-bottom: 1px solid var(--border);
 }
 
-/* ---------- Bottom CTA block ---------- */
-
-.cta-block {
-    background: var(--text);
-    color: var(--bg);
-    border-radius: 12px;
-    padding: 2.5rem 2rem;
-    margin-top: 4rem;
-}
-
-.cta-block h2 {
-    font-family: var(--font-sans);
-    font-weight: 700;
-    font-size: 1.75rem;
-    letter-spacing: -0.02em;
-    margin-bottom: 0.5rem;
-    color: var(--bg);
-}
-
-.cta-block p {
-    color: var(--bg);
-    opacity: 0.7;
+.cv-section h2 {
     margin-bottom: 1.5rem;
-    max-width: 50ch;
-}
-
-.cta-block .btn-primary {
-    background: var(--bg);
     color: var(--text);
+    font-size: clamp(1.75rem, 4vw, 2.6rem);
+    line-height: 1.05;
+    letter-spacing: -0.03em;
 }
 
-.cta-block .cta-meta {
-    color: var(--bg);
-    opacity: 0.7;
+.fit-list,
+.credit-list {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+    list-style: none;
 }
 
-.cta-block .cta-meta a {
-    color: var(--bg);
+.fit-list li,
+.credit-list li {
+    padding: 0.85rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text);
+    background: var(--cv-surface);
+    line-height: 1.45;
 }
 
-.cta-block .cta-meta a:hover {
-    opacity: 1;
+.experience-list {
+    display: grid;
+    gap: 2rem;
 }
 
-/* ---------- Footer ---------- */
-
-.footer {
-    max-width: 760px;
-    margin: 3rem auto 0;
-    padding: 2rem 1.5rem;
-    border-top: 1px solid var(--border);
+.experience-item header {
     display: flex;
     justify-content: space-between;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 0.75rem;
+    gap: 1.5rem;
+    margin-bottom: 0.85rem;
 }
 
-.footer-links {
+.experience-item h3,
+.skill-group h3,
+.education-list h3 {
+    color: var(--text);
+    font-size: 1.1rem;
+    letter-spacing: -0.01em;
+}
+
+.experience-item header p:not(.experience-meta),
+.education-list p {
+    margin-top: 0.25rem;
+    color: var(--text-muted);
+}
+
+.experience-item > p {
+    max-width: 68ch;
+    margin-bottom: 0.8rem;
+    color: var(--text-muted);
+    line-height: 1.65;
+}
+
+.experience-item ul {
+    display: grid;
+    gap: 0.45rem;
+    padding-left: 1.1rem;
+    color: var(--text);
+    line-height: 1.6;
+}
+
+.skills-grid,
+.education-list {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+}
+
+.skill-group,
+.education-list article {
+    padding: 1rem;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--cv-surface);
+}
+
+.skill-group ul {
     display: flex;
     flex-wrap: wrap;
-    gap: 1.25rem;
+    gap: 0.5rem;
+    margin-top: 0.85rem;
+    list-style: none;
 }
 
-.footer-links a {
-    font-family: var(--font-mono);
-    font-size: 0.75rem;
+.skill-group li {
+    padding: 0.35rem 0.55rem;
+    border-radius: 4px;
+    background: var(--bg);
     color: var(--text-muted);
-    text-decoration: none;
-}
-
-.footer-links a:hover { color: var(--accent); }
-
-.footer-copy {
     font-family: var(--font-mono);
-    font-size: 0.72rem;
-    color: var(--text-muted);
-    opacity: 0.7;
+    font-size: 0.74rem;
 }
 
-/* ---------- Responsive ---------- */
+.cv-contact {
+    border-bottom: 0;
+}
 
-@media (max-width: 600px) {
-    .page { padding: 1.5rem 1.25rem 3rem; }
-    .topbar { padding: 1rem 1.25rem; }
-    .hero { padding: 1.5rem 0 2.5rem; margin-bottom: 2.5rem; }
-    .cta-block { padding: 2rem 1.5rem; }
-    .footer { flex-direction: column; align-items: flex-start; padding: 2rem 1.25rem; }
-    .btn-primary { width: 100%; text-align: center; }
+.cv-contact p {
+    max-width: 58ch;
+    color: var(--text-muted);
+    line-height: 1.7;
+}
+
+@media (max-width: 820px) {
+    .cv-hero,
+    .cv-section {
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+    }
+
+    .cv-hero {
+        padding-top: 2rem;
+    }
+}
+
+@media (max-width: 620px) {
+    .page {
+        padding: 2rem 1.2rem 4rem;
+    }
+
+    .fit-list,
+    .credit-list,
+    .skills-grid,
+    .education-list {
+        grid-template-columns: 1fr;
+    }
+
+    .experience-item header {
+        flex-direction: column;
+        gap: 0.4rem;
+    }
+
+    .btn-primary {
+        width: 100%;
+    }
 }

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -139,7 +139,6 @@
 
 .cv-main {
     padding: 3.5rem 3.5rem 6rem;
-    max-width: 780px;
 }
 
 /* ── Sections ────────────────────────────── */

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -102,41 +102,6 @@ html {
     opacity: 0.65;
 }
 
-/* ── Section nav ─────────────────────────── */
-
-.cv-section-nav {
-    display: flex;
-    gap: 0;
-    border-bottom: 1px solid var(--border);
-    overflow-x: auto;
-    scrollbar-width: none;
-    -webkit-overflow-scrolling: touch;
-}
-
-.cv-section-nav::-webkit-scrollbar {
-    display: none;
-}
-
-.cv-section-nav a {
-    flex-shrink: 0;
-    padding: 0.65rem 1.1rem;
-    color: var(--text-muted);
-    font-family: var(--font-mono);
-    font-size: 0.7rem;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    text-decoration: none;
-    border-bottom: 2px solid transparent;
-    margin-bottom: -1px;
-    transition: color 0.12s, border-color 0.12s;
-    white-space: nowrap;
-}
-
-.cv-section-nav a:hover {
-    color: var(--text);
-    border-bottom-color: var(--text);
-    opacity: 1;
-}
 
 /* ── Scroll offset for fixed nav ─────────── */
 

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -448,35 +448,64 @@
     .cv-sidebar {
         position: static;
         height: auto;
-        padding: 2rem 1.5rem 1.75rem;
+        padding: 1.5rem 1.5rem 1.25rem;
         border-right: none;
         border-bottom: 1px solid var(--border);
         overflow-y: visible;
     }
 
     .cv-sidebar__inner {
-        gap: 1.5rem;
+        gap: 1rem;
     }
 
+    .cv-sidebar__name {
+        font-size: 1.15rem;
+    }
+
+    .cv-sidebar__role {
+        font-size: 0.8rem;
+        margin-top: 0.3rem;
+    }
+
+    .cv-sidebar__location {
+        font-size: 0.65rem;
+    }
+
+    /* Nav scrolls horizontally — no wrapping */
     .cv-sidebar__nav {
         flex-direction: row;
-        flex-wrap: wrap;
-        gap: 0.25rem 0.35rem;
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        gap: 0.2rem;
+        padding-bottom: 2px;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
+    }
+
+    .cv-sidebar__nav::-webkit-scrollbar {
+        display: none;
     }
 
     .cv-sidebar__nav a {
-        padding: 0.35rem 0.55rem;
-        font-size: 0.82rem;
+        flex-shrink: 0;
+        white-space: nowrap;
+        padding: 0.35rem 0.6rem;
+        font-size: 0.8rem;
     }
 
     .cv-sidebar__links {
         flex-direction: row;
         flex-wrap: wrap;
-        gap: 0.5rem 1.25rem;
+        gap: 0.4rem 1rem;
+    }
+
+    .cv-sidebar__links a {
+        font-size: 0.68rem;
+        word-break: normal;
     }
 
     .cv-main {
-        padding: 2.5rem 1.5rem 5rem;
+        padding: 2rem 1.5rem 5rem;
         max-width: 100%;
     }
 }
@@ -485,15 +514,19 @@
 
 @media (max-width: 520px) {
     .cv-sidebar {
-        padding: 1.75rem 1.2rem 1.5rem;
+        padding: 1.25rem 1.2rem 1rem;
     }
 
     .cv-main {
-        padding: 2rem 1.2rem 4rem;
+        padding: 1.75rem 1.2rem 4rem;
     }
 
     .section-heading {
-        font-size: 1.35rem;
+        font-size: 1.3rem;
+    }
+
+    .lede {
+        font-size: 1.05rem;
     }
 
     .timeline {
@@ -511,6 +544,14 @@
     .timeline-item__meta {
         flex-wrap: wrap;
         gap: 0.35rem;
+    }
+
+    /* Email address truncates rather than wrapping */
+    .cv-sidebar__links a[href^="mailto"] {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        max-width: 100%;
     }
 
     .btn-primary {

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -438,7 +438,7 @@
     opacity: 0.8;
 }
 
-/* ── Tablet (sidebar collapses to top bar) ─ */
+/* ── Tablet / mobile (sidebar becomes compact header) ── */
 
 @media (max-width: 860px) {
     .cv-layout {
@@ -448,31 +448,60 @@
     .cv-sidebar {
         position: static;
         height: auto;
-        padding: 1.5rem 1.5rem 1.25rem;
+        padding: 1.25rem 1.5rem 1rem;
         border-right: none;
         border-bottom: 1px solid var(--border);
-        overflow-y: visible;
+        overflow: visible;
     }
 
+    /* Two-column grid: identity left, links right; nav spans full width */
     .cv-sidebar__inner {
-        gap: 1rem;
+        display: grid;
+        grid-template-columns: 1fr auto;
+        grid-template-areas:
+            "identity links"
+            "nav      nav";
+        gap: 0.85rem 1.5rem;
+        align-items: start;
+    }
+
+    .cv-sidebar__identity {
+        grid-area: identity;
     }
 
     .cv-sidebar__name {
-        font-size: 1.15rem;
+        font-size: 1.1rem;
     }
 
     .cv-sidebar__role {
         font-size: 0.8rem;
-        margin-top: 0.3rem;
+        margin-top: 0.25rem;
     }
 
     .cv-sidebar__location {
         font-size: 0.65rem;
+        margin-top: 0.2rem;
     }
 
-    /* Nav scrolls horizontally — no wrapping */
+    /* Contact links stack on the right */
+    .cv-sidebar__links {
+        grid-area: links;
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 0.45rem;
+        border-top: none;
+        padding-top: 0;
+    }
+
+    .cv-sidebar__links a {
+        font-size: 0.68rem;
+        word-break: normal;
+        white-space: nowrap;
+    }
+
+    /* Nav scrolls horizontally as a single row */
     .cv-sidebar__nav {
+        grid-area: nav;
         flex-direction: row;
         flex-wrap: nowrap;
         overflow-x: auto;
@@ -480,6 +509,9 @@
         padding-bottom: 2px;
         -webkit-overflow-scrolling: touch;
         scrollbar-width: none;
+        border-top: 1px solid var(--border);
+        padding-top: 0.75rem;
+        margin-top: 0.1rem;
     }
 
     .cv-sidebar__nav::-webkit-scrollbar {
@@ -489,19 +521,8 @@
     .cv-sidebar__nav a {
         flex-shrink: 0;
         white-space: nowrap;
-        padding: 0.35rem 0.6rem;
-        font-size: 0.8rem;
-    }
-
-    .cv-sidebar__links {
-        flex-direction: row;
-        flex-wrap: wrap;
-        gap: 0.4rem 1rem;
-    }
-
-    .cv-sidebar__links a {
-        font-size: 0.68rem;
-        word-break: normal;
+        padding: 0.3rem 0.6rem;
+        font-size: 0.78rem;
     }
 
     .cv-main {
@@ -514,7 +535,11 @@
 
 @media (max-width: 520px) {
     .cv-sidebar {
-        padding: 1.25rem 1.2rem 1rem;
+        padding: 1rem 1.2rem 0.85rem;
+    }
+
+    .cv-sidebar__inner {
+        gap: 0.65rem 1rem;
     }
 
     .cv-main {
@@ -544,14 +569,6 @@
     .timeline-item__meta {
         flex-wrap: wrap;
         gap: 0.35rem;
-    }
-
-    /* Email address truncates rather than wrapping */
-    .cv-sidebar__links a[href^="mailto"] {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        max-width: 100%;
     }
 
     .btn-primary {

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -124,6 +124,17 @@
     opacity: 1;
 }
 
+.cv-sidebar__social-link {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+}
+
+.cv-sidebar__social-link svg {
+    flex-shrink: 0;
+    opacity: 0.7;
+}
+
 /* ── Main content ────────────────────────── */
 
 .cv-main {

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -1,5 +1,11 @@
 @import url('base.css');
 
+/* ── Smooth scrolling ────────────────────── */
+
+html {
+    scroll-behavior: smooth;
+}
+
 /* ── Page background ─────────────────────── */
 
 .cv-page-main {
@@ -94,6 +100,48 @@
 .cv-social-link svg {
     flex-shrink: 0;
     opacity: 0.65;
+}
+
+/* ── Section nav ─────────────────────────── */
+
+.cv-section-nav {
+    display: flex;
+    gap: 0;
+    border-bottom: 1px solid var(--border);
+    overflow-x: auto;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+}
+
+.cv-section-nav::-webkit-scrollbar {
+    display: none;
+}
+
+.cv-section-nav a {
+    flex-shrink: 0;
+    padding: 0.65rem 1.1rem;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    text-decoration: none;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+    transition: color 0.12s, border-color 0.12s;
+    white-space: nowrap;
+}
+
+.cv-section-nav a:hover {
+    color: var(--text);
+    border-bottom-color: var(--text);
+    opacity: 1;
+}
+
+/* ── Scroll offset for fixed nav ─────────── */
+
+[id] {
+    scroll-margin-top: calc(var(--nav-height) + 3.5rem);
 }
 
 /* ── Body: two-column grid ───────────────── */

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -1,573 +1,393 @@
 @import url('base.css');
 
-:root {
-    --sidebar-width: 260px;
-    --sidebar-bg: #f0f0ed;
-    --cv-surface: #ffffff;
-}
-
-[data-theme="dark"] {
-    --sidebar-bg: #0d0d0d;
-    --cv-surface: #161616;
-}
-
-/* ── Page main override ──────────────────── */
+/* ── Page background ─────────────────────── */
 
 .cv-page-main {
-    padding: 0;
+    padding: 3rem 1.5rem 5rem;
+    background: #e8e6e0;
 }
 
-/* ── Layout ──────────────────────────────── */
-
-.cv-layout {
-    display: grid;
-    grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
-    min-height: calc(100vh - var(--nav-height));
+[data-theme="dark"] .cv-page-main {
+    background: #0d0d0d;
 }
 
-/* ── Sidebar ─────────────────────────────── */
+/* ── Card wrapper ────────────────────────── */
 
-.cv-sidebar {
-    position: sticky;
-    top: var(--nav-height);
-    height: calc(100vh - var(--nav-height));
-    overflow-y: auto;
-    padding: 3rem 1.75rem;
-    border-right: 1px solid var(--border);
-    background: var(--sidebar-bg);
-    scrollbar-width: thin;
-    scrollbar-color: var(--border) transparent;
+.cv-wrap {
+    max-width: 980px;
+    margin: 0 auto;
 }
 
-.cv-sidebar__inner {
+.cv-card {
+    background: var(--bg);
+    border-radius: 4px;
+    box-shadow: 0 4px 40px rgba(0, 0, 0, 0.12);
+    overflow: hidden;
+}
+
+[data-theme="dark"] .cv-card {
+    box-shadow: 0 4px 40px rgba(0, 0, 0, 0.5);
+}
+
+/* ── Header ──────────────────────────────── */
+
+.cv-header {
     display: flex;
-    flex-direction: column;
-    gap: 2.5rem;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 2rem;
+    padding: 2.25rem 2.5rem;
+    border-bottom: 2px solid var(--text);
 }
 
-.cv-sidebar__name {
-    color: var(--text);
-    font-size: 1.4rem;
+.cv-name {
+    font-size: clamp(1.6rem, 4vw, 2.5rem);
     font-weight: 700;
-    line-height: 1.15;
-    letter-spacing: -0.03em;
-    max-width: none;
-}
-
-.cv-sidebar__role {
-    margin-top: 0.5rem;
-    color: var(--text);
-    font-size: 0.875rem;
-    font-weight: 500;
-    line-height: 1.45;
-    max-width: none;
-}
-
-.cv-sidebar__location {
-    display: block;
-    margin-top: 0.4rem;
-    color: var(--text-muted);
-    font-family: var(--font-mono);
-    font-size: 0.7rem;
     letter-spacing: 0.06em;
     text-transform: uppercase;
-    max-width: none;
-}
-
-/* ── Sidebar nav ─────────────────────────── */
-
-.cv-sidebar__nav {
-    display: flex;
-    flex-direction: column;
-    gap: 0.15rem;
-}
-
-.cv-sidebar__nav a {
-    display: block;
-    padding: 0.45rem 0.65rem;
-    border-radius: 5px;
-    color: var(--text-muted);
-    font-family: var(--font-sans);
-    font-size: 0.85rem;
-    text-decoration: none;
-    transition: color 0.12s, background 0.12s;
-}
-
-.cv-sidebar__nav a:hover {
+    line-height: 1.1;
     color: var(--text);
-    background: var(--border);
-    opacity: 1;
 }
 
-/* ── Sidebar links ───────────────────────── */
+.cv-subtitle {
+    margin-top: 0.35rem;
+    color: var(--text-muted);
+    font-size: 0.875rem;
+    font-weight: 400;
+    letter-spacing: 0.02em;
+    line-height: 1.4;
+}
 
-.cv-sidebar__links {
+.cv-header__contact {
     display: flex;
     flex-direction: column;
-    gap: 0.65rem;
-    padding-top: 0.5rem;
-    border-top: 1px solid var(--border);
+    align-items: flex-end;
+    gap: 0.35rem;
+    flex-shrink: 0;
 }
 
-.cv-sidebar__links a {
+.cv-header__contact a,
+.cv-location {
     color: var(--text-muted);
     font-family: var(--font-mono);
-    font-size: 0.7rem;
+    font-size: 0.72rem;
     text-decoration: none;
-    word-break: break-all;
+    letter-spacing: 0.02em;
     transition: color 0.12s;
-    max-width: none;
 }
 
-.cv-sidebar__links a:hover {
+.cv-header__contact a:hover {
     color: var(--accent);
     opacity: 1;
 }
 
-.cv-sidebar__social-link {
-    display: flex;
+.cv-location {
+    display: block;
+}
+
+.cv-social-link {
+    display: inline-flex;
     align-items: center;
-    gap: 0.45rem;
+    gap: 0.35rem;
 }
 
-.cv-sidebar__social-link svg {
+.cv-social-link svg {
     flex-shrink: 0;
-    opacity: 0.7;
+    opacity: 0.65;
 }
 
-/* ── Main content ────────────────────────── */
+/* ── Body: two-column grid ───────────────── */
 
-.cv-main {
-    padding: 3.5rem 3.5rem 6rem;
+.cv-body {
+    display: grid;
+    grid-template-columns: 230px minmax(0, 1fr);
 }
 
-/* ── Sections ────────────────────────────── */
+/* ── Left column ─────────────────────────── */
+
+.cv-col--left {
+    padding: 2rem 1.75rem;
+    border-right: 1px solid var(--border);
+}
+
+/* ── Right column ────────────────────────── */
+
+.cv-col--right {
+    padding: 2rem 2.5rem;
+}
+
+/* ── Section ─────────────────────────────── */
 
 .cv-section {
-    padding-bottom: 3.5rem;
-    margin-bottom: 3.5rem;
-    border-bottom: 1px solid var(--border);
-}
-
-.cv-contact {
-    border-bottom: none;
-    margin-bottom: 0;
-    padding-bottom: 0;
-}
-
-.section-heading {
     margin-bottom: 2rem;
-    color: var(--text);
-    font-size: clamp(1.4rem, 2.5vw, 1.9rem);
-    font-weight: 700;
-    letter-spacing: -0.03em;
-    line-height: 1.1;
 }
 
-/* ── Intro ───────────────────────────────── */
-
-.cv-intro {
-    padding-top: 0.25rem;
+.cv-section:last-child {
+    margin-bottom: 0;
 }
 
-.eyebrow {
-    display: inline-block;
+/* ── Section label ───────────────────────── */
+
+.cv-label {
     margin-bottom: 1rem;
-    color: var(--accent);
-    font-family: var(--font-mono);
+    padding-bottom: 0.35rem;
+    border-bottom: 1.5px solid var(--text);
+    color: var(--text);
     font-size: 0.7rem;
+    font-weight: 700;
     letter-spacing: 0.12em;
     text-transform: uppercase;
-}
-
-.lede {
-    margin-bottom: 1rem;
-    color: var(--text);
-    font-size: 1.2rem;
-    font-weight: 500;
-    line-height: 1.5;
-    max-width: 58ch;
-}
-
-.cv-summary {
-    color: var(--text-muted);
-    font-size: 0.95rem;
-    line-height: 1.8;
-    max-width: 66ch;
-}
-
-.fit-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    margin-top: 1.5rem;
-    list-style: none;
-}
-
-.fit-list li {
-    padding: 0.4rem 0.85rem;
-    border: 1px solid var(--border);
-    border-radius: 5px;
-    background: var(--cv-surface);
-    color: var(--text-muted);
-    font-size: 0.85rem;
-    line-height: 1.4;
-}
-
-/* ── Timeline ────────────────────────────── */
-
-.timeline {
-    position: relative;
-    padding-left: 1.5rem;
-}
-
-.timeline::before {
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 0.45rem;
-    bottom: 2rem;
-    width: 1px;
-    background: var(--border);
-}
-
-.timeline-item {
-    position: relative;
-    padding-bottom: 2.5rem;
-}
-
-.timeline-item:last-child {
-    padding-bottom: 0;
-}
-
-.timeline-item::before {
-    content: '';
-    position: absolute;
-    left: calc(-1.5rem - 3px);
-    top: 0.45rem;
-    width: 7px;
-    height: 7px;
-    border-radius: 50%;
-    background: var(--accent);
-}
-
-.timeline-item__meta {
-    display: flex;
-    gap: 1rem;
-    margin-bottom: 0.4rem;
-    color: var(--text-muted);
-    font-family: var(--font-mono);
-    font-size: 0.7rem;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    max-width: none;
-    line-height: 1.4;
-}
-
-.timeline-item__role {
-    color: var(--text);
-    font-size: 1rem;
-    font-weight: 600;
-    letter-spacing: -0.01em;
-    line-height: 1.3;
-}
-
-.timeline-item__company {
-    margin-top: 0.2rem;
-    color: var(--text-muted);
-    font-size: 0.875rem;
-    max-width: none;
-}
-
-.timeline-item__summary {
-    margin-top: 0.65rem;
-    color: var(--text-muted);
-    font-size: 0.9rem;
-    line-height: 1.7;
-    max-width: 60ch;
-}
-
-.timeline-item__highlights {
-    margin-top: 0.75rem;
-    padding-left: 1.1rem;
-    display: grid;
-    gap: 0.4rem;
-    color: var(--text);
-    font-size: 0.875rem;
-    line-height: 1.65;
-}
-
-/* ── Skills ──────────────────────────────── */
-
-.skill-groups {
-    display: grid;
-    gap: 1.75rem;
-}
-
-.skill-group__label {
-    margin-bottom: 0.75rem;
-    color: var(--text-muted);
-    font-family: var(--font-mono);
-    font-size: 0.7rem;
-    font-weight: 400;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-}
-
-.skill-chips {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.45rem;
-    list-style: none;
-}
-
-.skill-chips li {
-    padding: 0.3rem 0.7rem;
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    background: var(--cv-surface);
-    color: var(--text);
-    font-family: var(--font-mono);
-    font-size: 0.78rem;
-    line-height: 1.4;
-}
-
-/* ── Credits ─────────────────────────────── */
-
-.credit-chips {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.6rem;
-    list-style: none;
-}
-
-.credit-chips li {
-    padding: 0.5rem 1rem;
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    background: var(--cv-surface);
-    color: var(--text);
-    font-size: 0.9rem;
     line-height: 1.4;
 }
 
 /* ── Education ───────────────────────────── */
 
-.education-list {
-    display: grid;
-    gap: 1.5rem;
+.edu-entry {
+    margin-bottom: 1.25rem;
 }
 
-.education-item h3 {
+.edu-entry:last-child {
+    margin-bottom: 0;
+}
+
+.edu-entry h3 {
     color: var(--text);
-    font-size: 0.975rem;
+    font-size: 0.85rem;
     font-weight: 600;
-    line-height: 1.3;
+    line-height: 1.35;
 }
 
-.education-item p {
+.edu-entry p {
+    margin-top: 0.15rem;
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    line-height: 1.45;
+}
+
+.edu-entry span {
+    display: block;
     margin-top: 0.2rem;
     color: var(--text-muted);
-    font-size: 0.875rem;
-    max-width: none;
-    line-height: 1.5;
+    font-family: var(--font-mono);
+    font-size: 0.67rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
 }
 
-.education-item span {
-    display: block;
-    margin-top: 0.25rem;
+/* ── Skills ──────────────────────────────── */
+
+.skill-entry {
+    margin-bottom: 1rem;
+}
+
+.skill-entry:last-child {
+    margin-bottom: 0;
+}
+
+.skill-entry h3 {
+    color: var(--text);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    margin-bottom: 0.2rem;
+}
+
+.skill-entry p {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    line-height: 1.55;
+}
+
+/* ── Studios ─────────────────────────────── */
+
+.studio-entry {
+    color: var(--text-muted);
+    font-size: 0.82rem;
+    line-height: 1.6;
+}
+
+/* ── Profile ─────────────────────────────── */
+
+.cv-profile-text {
+    color: var(--text-muted);
+    font-size: 0.875rem;
+    line-height: 1.75;
+}
+
+/* ── Experience ──────────────────────────── */
+
+.exp-item {
+    margin-bottom: 1.75rem;
+    padding-bottom: 1.75rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.exp-item:last-child {
+    margin-bottom: 0;
+    padding-bottom: 0;
+    border-bottom: none;
+}
+
+.exp-item__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 1rem;
+    margin-bottom: 0.2rem;
+}
+
+.exp-item__role {
+    color: var(--text);
+    font-size: 0.9rem;
+    font-weight: 600;
+    line-height: 1.35;
+}
+
+.exp-item__period {
+    flex-shrink: 0;
     color: var(--text-muted);
     font-family: var(--font-mono);
-    font-size: 0.7rem;
-    letter-spacing: 0.06em;
+    font-size: 0.67rem;
+    letter-spacing: 0.05em;
     text-transform: uppercase;
+    white-space: nowrap;
+}
+
+.exp-item__company {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    font-style: italic;
+    margin-bottom: 0.55rem;
+}
+
+.exp-item__list {
+    padding-left: 1.1rem;
+    margin: 0;
+    display: grid;
+    gap: 0.3rem;
+    color: var(--text-muted);
+    font-size: 0.82rem;
+    line-height: 1.6;
 }
 
 /* ── Contact ─────────────────────────────── */
 
-.cv-contact p {
-    margin-bottom: 1.75rem;
+.cv-contact-section {
+    border-bottom: none;
+    margin-bottom: 0;
+    padding-bottom: 0;
+}
+
+.cv-contact-body {
     color: var(--text-muted);
-    font-size: 0.95rem;
-    line-height: 1.75;
-    max-width: 58ch;
+    font-size: 0.875rem;
+    line-height: 1.7;
+    margin-bottom: 1.25rem;
 }
 
 .cv-cta {
     display: flex;
     flex-wrap: wrap;
-    gap: 1rem;
+    gap: 0.75rem;
     align-items: center;
 }
 
-.cv-cta a:not(.btn-primary) {
+.btn-primary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.25rem;
+    padding: 0.55rem 1.1rem;
+    border-radius: 4px;
+    background: var(--text);
+    color: var(--bg) !important;
+    font-family: var(--font-sans) !important;
+    font-size: 0.825rem;
+    font-weight: 600;
+    text-decoration: none;
+    letter-spacing: 0.02em;
+    transition: opacity 0.12s;
+}
+
+.btn-primary:hover {
+    opacity: 0.78;
+}
+
+.btn-ghost {
     color: var(--text-muted);
     font-family: var(--font-mono);
-    font-size: 0.8rem;
+    font-size: 0.75rem;
     text-decoration: none;
     border-bottom: 1px solid var(--border);
     padding-bottom: 1px;
     transition: color 0.12s;
 }
 
-.cv-cta a:not(.btn-primary):hover {
+.btn-ghost:hover {
     color: var(--accent);
     opacity: 1;
 }
 
-/* ── Button ──────────────────────────────── */
+/* ── Tablet ──────────────────────────────── */
 
-.btn-primary {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 2.5rem;
-    padding: 0.65rem 1.25rem;
-    border-radius: 6px;
-    background: var(--text);
-    color: var(--bg) !important;
-    font-family: var(--font-sans) !important;
-    font-size: 0.875rem;
-    font-weight: 600;
-    text-decoration: none;
-    transition: opacity 0.12s;
-}
+@media (max-width: 760px) {
+    .cv-page-main {
+        padding: 1.5rem 1rem 4rem;
+    }
 
-.btn-primary:hover {
-    opacity: 0.8;
-}
+    .cv-header {
+        flex-direction: column;
+        gap: 1.25rem;
+        padding: 1.75rem 1.5rem;
+    }
 
-/* ── Tablet / mobile (sidebar becomes compact header) ── */
+    .cv-header__contact {
+        align-items: flex-start;
+    }
 
-@media (max-width: 860px) {
-    .cv-layout {
+    .cv-body {
         grid-template-columns: 1fr;
     }
 
-    .cv-sidebar {
-        position: static;
-        height: auto;
-        padding: 1.25rem 1.5rem 1rem;
+    .cv-col--left {
+        order: 2;
+        padding: 1.5rem;
         border-right: none;
-        border-bottom: 1px solid var(--border);
-        overflow: visible;
-    }
-
-    /* Two-column grid: identity left, links right; nav spans full width */
-    .cv-sidebar__inner {
-        display: grid;
-        grid-template-columns: 1fr auto;
-        grid-template-areas:
-            "identity links"
-            "nav      nav";
-        gap: 0.85rem 1.5rem;
-        align-items: start;
-    }
-
-    .cv-sidebar__identity {
-        grid-area: identity;
-    }
-
-    .cv-sidebar__name {
-        font-size: 1.1rem;
-    }
-
-    .cv-sidebar__role {
-        font-size: 0.8rem;
-        margin-top: 0.25rem;
-    }
-
-    .cv-sidebar__location {
-        font-size: 0.65rem;
-        margin-top: 0.2rem;
-    }
-
-    /* Contact links stack on the right */
-    .cv-sidebar__links {
-        grid-area: links;
-        flex-direction: column;
-        align-items: flex-end;
-        gap: 0.45rem;
-        border-top: none;
-        padding-top: 0;
-    }
-
-    .cv-sidebar__links a {
-        font-size: 0.68rem;
-        word-break: normal;
-        white-space: nowrap;
-    }
-
-    /* Nav scrolls horizontally as a single row */
-    .cv-sidebar__nav {
-        grid-area: nav;
-        flex-direction: row;
-        flex-wrap: nowrap;
-        overflow-x: auto;
-        gap: 0.2rem;
-        padding-bottom: 2px;
-        -webkit-overflow-scrolling: touch;
-        scrollbar-width: none;
         border-top: 1px solid var(--border);
-        padding-top: 0.75rem;
-        margin-top: 0.1rem;
     }
 
-    .cv-sidebar__nav::-webkit-scrollbar {
-        display: none;
-    }
-
-    .cv-sidebar__nav a {
-        flex-shrink: 0;
-        white-space: nowrap;
-        padding: 0.3rem 0.6rem;
-        font-size: 0.78rem;
-    }
-
-    .cv-main {
-        padding: 2rem 1.5rem 5rem;
-        max-width: 100%;
+    .cv-col--right {
+        order: 1;
+        padding: 1.5rem;
     }
 }
 
 /* ── Mobile ──────────────────────────────── */
 
-@media (max-width: 520px) {
-    .cv-sidebar {
-        padding: 1rem 1.2rem 0.85rem;
+@media (max-width: 480px) {
+    .cv-page-main {
+        padding: 0.75rem 0 3rem;
+        background: var(--bg);
     }
 
-    .cv-sidebar__inner {
-        gap: 0.65rem 1rem;
+    .cv-card {
+        border-radius: 0;
+        box-shadow: none;
     }
 
-    .cv-main {
-        padding: 1.75rem 1.2rem 4rem;
+    .cv-header {
+        padding: 1.25rem 1.1rem;
     }
 
-    .section-heading {
-        font-size: 1.3rem;
+    .cv-col--left,
+    .cv-col--right {
+        padding: 1.25rem 1.1rem;
     }
 
-    .lede {
-        font-size: 1.05rem;
-    }
-
-    .timeline {
-        padding-left: 1.25rem;
-    }
-
-    .timeline::before {
-        bottom: 1.5rem;
-    }
-
-    .timeline-item::before {
-        left: calc(-1.25rem - 3px);
-    }
-
-    .timeline-item__meta {
-        flex-wrap: wrap;
-        gap: 0.35rem;
+    .exp-item__header {
+        flex-direction: column;
+        gap: 0.2rem;
     }
 
     .btn-primary {

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -1,281 +1,509 @@
 @import url('base.css');
 
 :root {
+    --sidebar-width: 260px;
+    --sidebar-bg: #f0f0ed;
     --cv-surface: #ffffff;
 }
 
 [data-theme="dark"] {
+    --sidebar-bg: #0d0d0d;
     --cv-surface: #161616;
 }
 
-.page {
-    max-width: 1040px;
-    margin: 0 auto;
-    padding: 3rem 1.5rem 5rem;
+/* ── Page main override ──────────────────── */
+
+.cv-page-main {
+    padding: 0;
 }
 
-.cv-hero {
+/* ── Layout ──────────────────────────────── */
+
+.cv-layout {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 320px;
-    gap: 3rem;
-    align-items: start;
-    padding: 4rem 0 3.5rem;
+    grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
+    min-height: calc(100vh - var(--nav-height));
+}
+
+/* ── Sidebar ─────────────────────────────── */
+
+.cv-sidebar {
+    position: sticky;
+    top: var(--nav-height);
+    height: calc(100vh - var(--nav-height));
+    overflow-y: auto;
+    padding: 3rem 1.75rem;
+    border-right: 1px solid var(--border);
+    background: var(--sidebar-bg);
+    scrollbar-width: thin;
+    scrollbar-color: var(--border) transparent;
+}
+
+.cv-sidebar__inner {
+    display: flex;
+    flex-direction: column;
+    gap: 2.5rem;
+}
+
+.cv-sidebar__name {
+    color: var(--text);
+    font-size: 1.4rem;
+    font-weight: 700;
+    line-height: 1.15;
+    letter-spacing: -0.03em;
+    max-width: none;
+}
+
+.cv-sidebar__role {
+    margin-top: 0.5rem;
+    color: var(--text);
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1.45;
+    max-width: none;
+}
+
+.cv-sidebar__location {
+    display: block;
+    margin-top: 0.4rem;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    max-width: none;
+}
+
+/* ── Sidebar nav ─────────────────────────── */
+
+.cv-sidebar__nav {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+}
+
+.cv-sidebar__nav a {
+    display: block;
+    padding: 0.45rem 0.65rem;
+    border-radius: 5px;
+    color: var(--text-muted);
+    font-family: var(--font-sans);
+    font-size: 0.85rem;
+    text-decoration: none;
+    transition: color 0.12s, background 0.12s;
+}
+
+.cv-sidebar__nav a:hover {
+    color: var(--text);
+    background: var(--border);
+    opacity: 1;
+}
+
+/* ── Sidebar links ───────────────────────── */
+
+.cv-sidebar__links {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid var(--border);
+}
+
+.cv-sidebar__links a {
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    text-decoration: none;
+    word-break: break-all;
+    transition: color 0.12s;
+    max-width: none;
+}
+
+.cv-sidebar__links a:hover {
+    color: var(--accent);
+    opacity: 1;
+}
+
+/* ── Main content ────────────────────────── */
+
+.cv-main {
+    padding: 3.5rem 3.5rem 6rem;
+    max-width: 780px;
+}
+
+/* ── Sections ────────────────────────────── */
+
+.cv-section {
+    padding-bottom: 3.5rem;
+    margin-bottom: 3.5rem;
     border-bottom: 1px solid var(--border);
 }
 
-.eyebrow,
-.section-kicker {
+.cv-contact {
+    border-bottom: none;
+    margin-bottom: 0;
+    padding-bottom: 0;
+}
+
+.section-heading {
+    margin-bottom: 2rem;
+    color: var(--text);
+    font-size: clamp(1.4rem, 2.5vw, 1.9rem);
+    font-weight: 700;
+    letter-spacing: -0.03em;
+    line-height: 1.1;
+}
+
+/* ── Intro ───────────────────────────────── */
+
+.cv-intro {
+    padding-top: 0.25rem;
+}
+
+.eyebrow {
     display: inline-block;
     margin-bottom: 1rem;
     color: var(--accent);
     font-family: var(--font-mono);
-    font-size: 0.72rem;
+    font-size: 0.7rem;
     letter-spacing: 0.12em;
     text-transform: uppercase;
 }
 
-.cv-hero h1 {
-    max-width: 11ch;
-    margin-bottom: 1rem;
-    color: var(--text);
-    font-size: clamp(3rem, 9vw, 6.5rem);
-    line-height: 0.95;
-    letter-spacing: -0.04em;
-}
-
-.cv-title {
-    margin-bottom: 1rem;
-    color: var(--text);
-    font-size: clamp(1.25rem, 3vw, 1.75rem);
-    font-weight: 600;
-}
-
 .lede {
-    max-width: 58ch;
-    margin-bottom: 1.25rem;
+    margin-bottom: 1rem;
     color: var(--text);
     font-size: 1.2rem;
-    line-height: 1.55;
+    font-weight: 500;
+    line-height: 1.5;
+    max-width: 58ch;
 }
 
 .cv-summary {
-    max-width: 68ch;
     color: var(--text-muted);
-    font-size: 1rem;
-    line-height: 1.75;
+    font-size: 0.95rem;
+    line-height: 1.8;
+    max-width: 66ch;
 }
 
-.cv-actions {
+.fit-list {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.85rem 1rem;
-    align-items: center;
-    margin-top: 1.75rem;
+    gap: 0.5rem;
+    margin-top: 1.5rem;
+    list-style: none;
 }
 
-.cv-actions a {
+.fit-list li {
+    padding: 0.4rem 0.85rem;
+    border: 1px solid var(--border);
+    border-radius: 5px;
+    background: var(--cv-surface);
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    line-height: 1.4;
+}
+
+/* ── Timeline ────────────────────────────── */
+
+.timeline {
+    position: relative;
+    padding-left: 1.5rem;
+}
+
+.timeline::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0.45rem;
+    bottom: 2rem;
+    width: 1px;
+    background: var(--border);
+}
+
+.timeline-item {
+    position: relative;
+    padding-bottom: 2.5rem;
+}
+
+.timeline-item:last-child {
+    padding-bottom: 0;
+}
+
+.timeline-item::before {
+    content: '';
+    position: absolute;
+    left: calc(-1.5rem - 3px);
+    top: 0.45rem;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--accent);
+}
+
+.timeline-item__meta {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 0.4rem;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    max-width: none;
+    line-height: 1.4;
+}
+
+.timeline-item__role {
+    color: var(--text);
+    font-size: 1rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    line-height: 1.3;
+}
+
+.timeline-item__company {
+    margin-top: 0.2rem;
+    color: var(--text-muted);
+    font-size: 0.875rem;
+    max-width: none;
+}
+
+.timeline-item__summary {
+    margin-top: 0.65rem;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    line-height: 1.7;
+    max-width: 60ch;
+}
+
+.timeline-item__highlights {
+    margin-top: 0.75rem;
+    padding-left: 1.1rem;
+    display: grid;
+    gap: 0.4rem;
+    color: var(--text);
+    font-size: 0.875rem;
+    line-height: 1.65;
+}
+
+/* ── Skills ──────────────────────────────── */
+
+.skill-groups {
+    display: grid;
+    gap: 1.75rem;
+}
+
+.skill-group__label {
+    margin-bottom: 0.75rem;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    font-weight: 400;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.skill-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    list-style: none;
+}
+
+.skill-chips li {
+    padding: 0.3rem 0.7rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--cv-surface);
     color: var(--text);
     font-family: var(--font-mono);
-    font-size: 0.82rem;
+    font-size: 0.78rem;
+    line-height: 1.4;
+}
+
+/* ── Credits ─────────────────────────────── */
+
+.credit-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    list-style: none;
+}
+
+.credit-chips li {
+    padding: 0.5rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--cv-surface);
+    color: var(--text);
+    font-size: 0.9rem;
+    line-height: 1.4;
+}
+
+/* ── Education ───────────────────────────── */
+
+.education-list {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.education-item h3 {
+    color: var(--text);
+    font-size: 0.975rem;
+    font-weight: 600;
+    line-height: 1.3;
+}
+
+.education-item p {
+    margin-top: 0.2rem;
+    color: var(--text-muted);
+    font-size: 0.875rem;
+    max-width: none;
+    line-height: 1.5;
+}
+
+.education-item span {
+    display: block;
+    margin-top: 0.25rem;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+/* ── Contact ─────────────────────────────── */
+
+.cv-contact p {
+    margin-bottom: 1.75rem;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    line-height: 1.75;
+    max-width: 58ch;
+}
+
+.cv-cta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+}
+
+.cv-cta a:not(.btn-primary) {
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
     text-decoration: none;
-}
-
-.cv-actions a:not(.btn-primary) {
     border-bottom: 1px solid var(--border);
+    padding-bottom: 1px;
+    transition: color 0.12s;
 }
 
-.cv-actions a:hover {
+.cv-cta a:not(.btn-primary):hover {
     color: var(--accent);
+    opacity: 1;
 }
+
+/* ── Button ──────────────────────────────── */
 
 .btn-primary {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-height: 2.65rem;
-    padding: 0.75rem 1.15rem;
+    min-height: 2.5rem;
+    padding: 0.65rem 1.25rem;
     border-radius: 6px;
     background: var(--text);
     color: var(--bg) !important;
     font-family: var(--font-sans) !important;
+    font-size: 0.875rem;
     font-weight: 600;
+    text-decoration: none;
+    transition: opacity 0.12s;
 }
 
-.cv-snapshot {
-    padding: 1.25rem;
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    background: var(--cv-surface);
+.btn-primary:hover {
+    opacity: 0.8;
 }
 
-.cv-snapshot dl {
-    display: grid;
-    gap: 1.1rem;
-}
+/* ── Tablet (sidebar collapses to top bar) ─ */
 
-.cv-snapshot dt,
-.experience-meta,
-.education-list span {
-    color: var(--text-muted);
-    font-family: var(--font-mono);
-    font-size: 0.72rem;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-}
-
-.cv-snapshot dd {
-    margin-top: 0.35rem;
-    color: var(--text);
-    line-height: 1.5;
-}
-
-.cv-section {
-    display: grid;
-    grid-template-columns: 220px minmax(0, 1fr);
-    gap: 2.5rem;
-    padding: 3rem 0;
-    border-bottom: 1px solid var(--border);
-}
-
-.cv-section h2 {
-    margin-bottom: 1.5rem;
-    color: var(--text);
-    font-size: clamp(1.75rem, 4vw, 2.6rem);
-    line-height: 1.05;
-    letter-spacing: -0.03em;
-}
-
-.fit-list,
-.credit-list {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.75rem;
-    list-style: none;
-}
-
-.fit-list li,
-.credit-list li {
-    padding: 0.85rem 1rem;
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    color: var(--text);
-    background: var(--cv-surface);
-    line-height: 1.45;
-}
-
-.experience-list {
-    display: grid;
-    gap: 2rem;
-}
-
-.experience-item header {
-    display: flex;
-    justify-content: space-between;
-    gap: 1.5rem;
-    margin-bottom: 0.85rem;
-}
-
-.experience-item h3,
-.skill-group h3,
-.education-list h3 {
-    color: var(--text);
-    font-size: 1.1rem;
-    letter-spacing: -0.01em;
-}
-
-.experience-item header p:not(.experience-meta),
-.education-list p {
-    margin-top: 0.25rem;
-    color: var(--text-muted);
-}
-
-.experience-item > p {
-    max-width: 68ch;
-    margin-bottom: 0.8rem;
-    color: var(--text-muted);
-    line-height: 1.65;
-}
-
-.experience-item ul {
-    display: grid;
-    gap: 0.45rem;
-    padding-left: 1.1rem;
-    color: var(--text);
-    line-height: 1.6;
-}
-
-.skills-grid,
-.education-list {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 1rem;
-}
-
-.skill-group,
-.education-list article {
-    padding: 1rem;
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    background: var(--cv-surface);
-}
-
-.skill-group ul {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    margin-top: 0.85rem;
-    list-style: none;
-}
-
-.skill-group li {
-    padding: 0.35rem 0.55rem;
-    border-radius: 4px;
-    background: var(--bg);
-    color: var(--text-muted);
-    font-family: var(--font-mono);
-    font-size: 0.74rem;
-}
-
-.cv-contact {
-    border-bottom: 0;
-}
-
-.cv-contact p {
-    max-width: 58ch;
-    color: var(--text-muted);
-    line-height: 1.7;
-}
-
-@media (max-width: 820px) {
-    .cv-hero,
-    .cv-section {
+@media (max-width: 860px) {
+    .cv-layout {
         grid-template-columns: 1fr;
+    }
+
+    .cv-sidebar {
+        position: static;
+        height: auto;
+        padding: 2rem 1.5rem 1.75rem;
+        border-right: none;
+        border-bottom: 1px solid var(--border);
+        overflow-y: visible;
+    }
+
+    .cv-sidebar__inner {
         gap: 1.5rem;
     }
 
-    .cv-hero {
-        padding-top: 2rem;
+    .cv-sidebar__nav {
+        flex-direction: row;
+        flex-wrap: wrap;
+        gap: 0.25rem 0.35rem;
+    }
+
+    .cv-sidebar__nav a {
+        padding: 0.35rem 0.55rem;
+        font-size: 0.82rem;
+    }
+
+    .cv-sidebar__links {
+        flex-direction: row;
+        flex-wrap: wrap;
+        gap: 0.5rem 1.25rem;
+    }
+
+    .cv-main {
+        padding: 2.5rem 1.5rem 5rem;
+        max-width: 100%;
     }
 }
 
-@media (max-width: 620px) {
-    .page {
+/* ── Mobile ──────────────────────────────── */
+
+@media (max-width: 520px) {
+    .cv-sidebar {
+        padding: 1.75rem 1.2rem 1.5rem;
+    }
+
+    .cv-main {
         padding: 2rem 1.2rem 4rem;
     }
 
-    .fit-list,
-    .credit-list,
-    .skills-grid,
-    .education-list {
-        grid-template-columns: 1fr;
+    .section-heading {
+        font-size: 1.35rem;
     }
 
-    .experience-item header {
-        flex-direction: column;
-        gap: 0.4rem;
+    .timeline {
+        padding-left: 1.25rem;
+    }
+
+    .timeline::before {
+        bottom: 1.5rem;
+    }
+
+    .timeline-item::before {
+        left: calc(-1.25rem - 3px);
+    }
+
+    .timeline-item__meta {
+        flex-wrap: wrap;
+        gap: 0.35rem;
     }
 
     .btn-primary {
         width: 100%;
+        justify-content: center;
     }
 }

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -144,6 +144,35 @@ html {
 }
 
 
+/* ── Skills ──────────────────────────────── */
+
+.skill-entry {
+    display: grid;
+    grid-template-columns: 180px 1fr;
+    gap: 0.5rem 1.5rem;
+    padding: 0.6rem 0;
+    border-bottom: 1px solid var(--border);
+    align-items: baseline;
+}
+
+.skill-entry:last-child {
+    border-bottom: none;
+}
+
+.skill-entry h3 {
+    color: var(--text-muted);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.skill-entry p {
+    color: var(--text);
+    font-size: 0.85rem;
+    line-height: 1.55;
+}
+
 /* ── Profile ─────────────────────────────── */
 
 .cv-profile-text {

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -112,11 +112,9 @@ html {
 /* ── Body ────────────────────────────────── */
 
 .cv-body {
-    padding: 2rem 2.5rem;
-}
-
-.cv-col {
+    padding: 2.5rem 3rem;
     max-width: 780px;
+    margin: 0 auto;
 }
 
 /* ── Section ─────────────────────────────── */
@@ -175,10 +173,17 @@ html {
 
 /* ── Profile ─────────────────────────────── */
 
+#profile.cv-section {
+    padding-bottom: 2.5rem;
+    margin-bottom: 2.5rem;
+}
+
 .cv-profile-text {
-    color: var(--text-muted);
-    font-size: 0.875rem;
-    line-height: 1.75;
+    color: var(--text);
+    font-size: 1.05rem;
+    font-weight: 400;
+    line-height: 1.8;
+    max-width: 62ch;
 }
 
 /* ── Experience ──────────────────────────── */
@@ -313,7 +318,7 @@ html {
     }
 
     .cv-body {
-        padding: 1.5rem;
+        padding: 1.75rem 1.5rem;
     }
 }
 

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -109,24 +109,14 @@ html {
     scroll-margin-top: calc(var(--nav-height) + 3.5rem);
 }
 
-/* ── Body: two-column grid ───────────────── */
+/* ── Body ────────────────────────────────── */
 
 .cv-body {
-    display: grid;
-    grid-template-columns: 230px minmax(0, 1fr);
-}
-
-/* ── Left column ─────────────────────────── */
-
-.cv-col--left {
-    padding: 2rem 1.75rem;
-    border-right: 1px solid var(--border);
-}
-
-/* ── Right column ────────────────────────── */
-
-.cv-col--right {
     padding: 2rem 2.5rem;
+}
+
+.cv-col {
+    max-width: 780px;
 }
 
 /* ── Section ─────────────────────────────── */
@@ -153,72 +143,6 @@ html {
     line-height: 1.4;
 }
 
-/* ── Education ───────────────────────────── */
-
-.edu-entry {
-    margin-bottom: 1.25rem;
-}
-
-.edu-entry:last-child {
-    margin-bottom: 0;
-}
-
-.edu-entry h3 {
-    color: var(--text);
-    font-size: 0.85rem;
-    font-weight: 600;
-    line-height: 1.35;
-}
-
-.edu-entry p {
-    margin-top: 0.15rem;
-    color: var(--text-muted);
-    font-size: 0.8rem;
-    line-height: 1.45;
-}
-
-.edu-entry span {
-    display: block;
-    margin-top: 0.2rem;
-    color: var(--text-muted);
-    font-family: var(--font-mono);
-    font-size: 0.67rem;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-}
-
-/* ── Skills ──────────────────────────────── */
-
-.skill-entry {
-    margin-bottom: 1rem;
-}
-
-.skill-entry:last-child {
-    margin-bottom: 0;
-}
-
-.skill-entry h3 {
-    color: var(--text);
-    font-size: 0.72rem;
-    font-weight: 600;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    margin-bottom: 0.2rem;
-}
-
-.skill-entry p {
-    color: var(--text-muted);
-    font-size: 0.8rem;
-    line-height: 1.55;
-}
-
-/* ── Studios ─────────────────────────────── */
-
-.studio-entry {
-    color: var(--text-muted);
-    font-size: 0.82rem;
-    line-height: 1.6;
-}
 
 /* ── Profile ─────────────────────────────── */
 
@@ -360,18 +284,6 @@ html {
     }
 
     .cv-body {
-        grid-template-columns: 1fr;
-    }
-
-    .cv-col--left {
-        order: 2;
-        padding: 1.5rem;
-        border-right: none;
-        border-top: 1px solid var(--border);
-    }
-
-    .cv-col--right {
-        order: 1;
         padding: 1.5rem;
     }
 }
@@ -393,8 +305,7 @@ html {
         padding: 1.25rem 1.1rem;
     }
 
-    .cv-col--left,
-    .cv-col--right {
+    .cv-body {
         padding: 1.25rem 1.1rem;
     }
 

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
-{% block title %}About | Game Dev Mentor — {{ config.name }}{% endblock %}
-{% block meta_description %}1:1 game development mentoring for beginners, hobbyists, and indie teams. Blizzard Entertainment alumni, currently mentoring at GameCityKajaani.{% endblock %}
+{% block title %}About | {{ config.name }}{% endblock %}
+{% block meta_description %}Professional bio for {{ config.name }}, Pipeline TD and software developer focused on Python tooling, DCC pipelines, and workflow automation.{% endblock %}
 
 {% block content %}
 <article class="about-page">
@@ -9,7 +9,7 @@
     <header class="about-header">
         <img
             src="{{ url_for('static', filename='images/SreyeeshProfilePic.jpg') }}"
-            alt="{{ config.name }}, game development mentor"
+            alt="{{ config.name }}"
             class="about-avatar"
         >
         <h1>About</h1>
@@ -17,48 +17,54 @@
 
     <div class="about-body">
         <p>
-            I'm {{ config.name }}, a 1:1 game development mentor based in {{ config.location }}.
-            I help complete beginners, hobbyists, and small indie teams get started in game dev,
-            pick the right engine, and finish the projects they start.
+            I'm {{ config.name }}, a Pipeline TD and software developer based in
+            {{ config.location }}. My work sits between creative production and
+            software: Python tools, DCC pipeline support, render workflows,
+            documentation, and the practical communication needed to help teams
+            ship.
         </p>
 
-        <h2>Background</h2>
+        <h2>Production background</h2>
         <p>
-            I've spent over a decade working in the games and animation industries,
-            most notably as a technical artist at Blizzard Entertainment. I currently
-            mentor aspiring game developers remotely with GameCityKajaani in Finland,
-            working with students at every stage, from people who have never opened a
-            game engine to teams shipping their first commercial project.
+            My studio experience includes DNEG, Walt Disney Animation Studios,
+            Blizzard Entertainment, Boulder Media, Encore VFX, FuseFX, and CoSA
+            VFX. Across those roles I have supported artists and production teams
+            through Python tooling, render support, show configuration work, DCC
+            troubleshooting, and pipeline workflow improvements.
         </p>
 
-        <h2>How I can help</h2>
+        <h2>Current focus</h2>
         <p>
-            Whether you are choosing between Godot, Unity, or Unreal, scoping your
-            first playable prototype, or pushing through the messy middle of a side
-            project, I offer focused 60-minute video sessions tailored to where you
-            actually are. Sessions are €75 each, with no long-term commitment.
-            <a href="{{ site_links.home }}">Book a session</a>, or email
-            <a href="mailto:{{ config.email }}">{{ config.email }}</a> if you have
-            questions first.
+            Through Toucan Studios OÜ, I also mentor junior developers and
+            creative technology learners on Python, Git, pipeline standards, and
+            technical problem-solving. I am interested in roles where production
+            experience, workflow automation, internal tools, and clear technical
+            support are useful beyond a single industry label.
         </p>
     </div>
 
-    {% if config.github_url or config.linkedin_url %}
+    {% if config.github_url or config.linkedin_url or config.imdb_url %}
     <hr class="about-divider">
 
     <section class="about-links">
         <h2>Elsewhere</h2>
         <ul class="elsewhere-list">
-            {% if config.github_url %}
-            <li>
-                <a href="{{ config.github_url }}" target="_blank" rel="noopener noreferrer">GitHub</a>
-                <span>code and open source</span>
-            </li>
-            {% endif %}
             {% if config.linkedin_url %}
             <li>
                 <a href="{{ config.linkedin_url }}" target="_blank" rel="noopener noreferrer">LinkedIn</a>
-                <span>work history</span>
+                <span>work history and contact</span>
+            </li>
+            {% endif %}
+            {% if config.github_url %}
+            <li>
+                <a href="{{ config.github_url }}" target="_blank" rel="noopener noreferrer">GitHub</a>
+                <span>code and project work</span>
+            </li>
+            {% endif %}
+            {% if config.imdb_url %}
+            <li>
+                <a href="{{ config.imdb_url }}" target="_blank" rel="noopener noreferrer">IMDb</a>
+                <span>production credits</span>
             </li>
             {% endif %}
         </ul>

--- a/templates/base.html
+++ b/templates/base.html
@@ -60,6 +60,7 @@
                 <span class="nav-section-divider" aria-hidden="true"></span>
                 <a class="nav-section-link" href="/#profile">Profile</a>
                 <a class="nav-section-link" href="/#experience">Experience</a>
+                <a class="nav-section-link" href="/#skills">Skills</a>
                 <a class="nav-section-link" href="/#contact">Contact</a>
             </div>
             <div class="nav-controls">

--- a/templates/base.html
+++ b/templates/base.html
@@ -60,8 +60,6 @@
                 <span class="nav-section-divider" aria-hidden="true"></span>
                 <a class="nav-section-link" href="/#profile">Profile</a>
                 <a class="nav-section-link" href="/#experience">Experience</a>
-                <a class="nav-section-link" href="/#skills">Skills</a>
-                <a class="nav-section-link" href="/#education">Education</a>
                 <a class="nav-section-link" href="/#contact">Contact</a>
             </div>
             <div class="nav-controls">

--- a/templates/base.html
+++ b/templates/base.html
@@ -57,6 +57,12 @@
                         {{ item.label }}
                     </a>
                 {% endfor %}
+                <span class="nav-section-divider" aria-hidden="true"></span>
+                <a class="nav-section-link" href="/#profile">Profile</a>
+                <a class="nav-section-link" href="/#experience">Experience</a>
+                <a class="nav-section-link" href="/#skills">Skills</a>
+                <a class="nav-section-link" href="/#education">Education</a>
+                <a class="nav-section-link" href="/#contact">Contact</a>
             </div>
             <div class="nav-controls">
                 <button id="dark-mode-toggle" class="dark-mode-toggle" aria-label="Toggle dark mode">

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -41,16 +41,6 @@
         </div>
     </header>
 
-    <!-- ── Section nav ── -->
-    <nav class="cv-section-nav" aria-label="Jump to section">
-        <a href="#profile">Profile</a>
-        <a href="#experience">Experience</a>
-        <a href="#skills">Skills</a>
-        <a href="#education">Education</a>
-        <a href="#studios">Studios</a>
-        <a href="#contact">Contact</a>
-    </nav>
-
     <!-- ── Body: two columns ── -->
     <div class="cv-body">
 

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -41,44 +41,10 @@
         </div>
     </header>
 
-    <!-- ── Body: two columns ── -->
+    <!-- ── Body ── -->
     <div class="cv-body">
 
-        <!-- Left column: Education · Skills · Studios -->
-        <aside class="cv-col cv-col--left">
-
-            <section id="education" class="cv-section" aria-labelledby="edu-label">
-                <h2 id="edu-label" class="cv-label">Education</h2>
-                {% for item in cv.education %}
-                <div class="edu-entry">
-                    <h3>{{ item.school }}</h3>
-                    <p>{{ item.credential }}</p>
-                    <span>{{ item.period }}</span>
-                </div>
-                {% endfor %}
-            </section>
-
-            <section id="skills" class="cv-section" aria-labelledby="skills-label">
-                <h2 id="skills-label" class="cv-label">Skills</h2>
-                {% for group in cv.skills %}
-                <div class="skill-entry">
-                    <h3>{{ group.group }}</h3>
-                    <p>{{ group['items'] | join(', ') }}</p>
-                </div>
-                {% endfor %}
-            </section>
-
-            <section id="studios" class="cv-section" aria-labelledby="studios-label">
-                <h2 id="studios-label" class="cv-label">Studios</h2>
-                {% for credit in cv.credits %}
-                <p class="studio-entry">{{ credit }}</p>
-                {% endfor %}
-            </section>
-
-        </aside>
-
-        <!-- Right column: Profile · Experience · Contact -->
-        <div class="cv-col cv-col--right">
+        <div class="cv-col">
 
             <section id="profile" class="cv-section" aria-labelledby="profile-label">
                 <h2 id="profile-label" class="cv-label">Profile</h2>

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 
-{% block title %}{{ config.name }} | {{ landing.page_title }}{% endblock %}
+{% block title %}{{ config.name }} | {{ cv.page_title }}{% endblock %}
 {% block meta_description %}{{ config.meta_description }}{% endblock %}
 
 {% block head_extra %}
@@ -8,80 +8,141 @@
 {% endblock %}
 
 {% block main_inner %}
-<div class="page landing-page">
+<div class="page cv-page">
 
-    <section class="hero">
-        <span class="eyebrow">{{ landing.eyebrow }}</span>
-        <h1>{{ landing.headline }}</h1>
-        <p class="lede">{{ landing.lede }}</p>
-        <div class="cta-row">
-            <a class="btn-primary" href="{{ booking_url }}" target="_blank" rel="noopener noreferrer">
-                {{ landing.cta_label }}<span class="sr-only"> (opens in new tab)</span>
-            </a>
-            <span class="cta-meta">{{ landing.cta_meta }}</span>
+    <section class="cv-hero" aria-labelledby="cv-title">
+        <div class="cv-hero__content">
+            <span class="eyebrow">{{ cv.eyebrow }}</span>
+            <h1 id="cv-title">{{ config.name }}</h1>
+            <p class="cv-title">{{ config.tagline }}</p>
+            <p class="lede">{{ cv.tagline }}</p>
+            <p class="cv-summary">{{ cv.summary }}</p>
+
+            <div class="cv-actions" aria-label="Contact and profile links">
+                <a class="btn-primary" href="mailto:{{ config.email }}">Email me</a>
+                {% if config.linkedin_url %}
+                <a href="{{ config.linkedin_url }}" target="_blank" rel="noopener noreferrer">
+                    LinkedIn<span class="sr-only"> (opens in new tab)</span>
+                </a>
+                {% endif %}
+                {% if config.phone %}
+                <a href="tel:{{ config.phone | replace(' ', '') }}">{{ config.phone }}</a>
+                {% endif %}
+                {% if config.github_url %}
+                <a href="{{ config.github_url }}" target="_blank" rel="noopener noreferrer">
+                    GitHub<span class="sr-only"> (opens in new tab)</span>
+                </a>
+                {% endif %}
+                {% if config.imdb_url %}
+                <a href="{{ config.imdb_url }}" target="_blank" rel="noopener noreferrer">
+                    IMDb<span class="sr-only"> (opens in new tab)</span>
+                </a>
+                {% endif %}
+            </div>
         </div>
-        <p class="trust">
-            {{ landing.trust }} · based in {{ config.location }}
-        </p>
+
+        <aside class="cv-snapshot" aria-label="Professional snapshot">
+            <dl>
+                <div>
+                    <dt>Based in</dt>
+                    <dd>{{ config.location }}</dd>
+                </div>
+                <div>
+                    <dt>Focus</dt>
+                    <dd>Python tooling, pipeline workflows, production support</dd>
+                </div>
+                <div>
+                    <dt>Open to</dt>
+                    <dd>Industry and adjacent technical roles</dd>
+                </div>
+            </dl>
+        </aside>
     </section>
 
-    <section class="block">
-        <span class="section-label">{{ landing.audience_label }}</span>
-        <h2 class="block-heading">{{ landing.audience_heading }}</h2>
-        <ul class="check-list">
-            {% for item in landing.audience %}
+    <section class="cv-section" aria-labelledby="fit-heading">
+        <div class="section-kicker">Role fit</div>
+        <h2 id="fit-heading">Where this profile fits</h2>
+        <ul class="fit-list">
+            {% for item in cv.fit %}
             <li>{{ item }}</li>
             {% endfor %}
         </ul>
     </section>
 
-    <section class="block">
-        <span class="section-label">{{ landing.topics_label }}</span>
-        <ul class="topic-list">
-            {% for topic in landing.topics %}
-            <li>
-                <span class="idx" aria-hidden="true">{{ '%02d' % loop.index }}</span>
-                {{ topic }}
-            </li>
+    <section class="cv-section" aria-labelledby="experience-heading">
+        <div class="section-kicker">Experience</div>
+        <h2 id="experience-heading">Recent work</h2>
+        <div class="experience-list">
+            {% for item in cv.experience %}
+            <article class="experience-item">
+                <header>
+                    <div>
+                        <h3>{{ item.role }}</h3>
+                        <p>{{ item.company }}</p>
+                    </div>
+                    <p class="experience-meta">{{ item.period }} · {{ item.location }}</p>
+                </header>
+                <p>{{ item.summary }}</p>
+                <ul>
+                    {% for highlight in item.highlights %}
+                    <li>{{ highlight }}</li>
+                    {% endfor %}
+                </ul>
+            </article>
+            {% endfor %}
+        </div>
+    </section>
+
+    <section class="cv-section" aria-labelledby="credits-heading">
+        <div class="section-kicker">Production context</div>
+        <h2 id="credits-heading">Studios and collaborators</h2>
+        <ul class="credit-list">
+            {% for credit in cv.credits %}
+            <li>{{ credit }}</li>
             {% endfor %}
         </ul>
     </section>
 
-    <section class="block">
-        <span class="section-label">{{ landing.steps_label }}</span>
-        <ol class="steps-list">
-            {% for step in landing.steps %}
-            <li>
-                <span class="idx" aria-hidden="true">{{ loop.index }}</span>
-                {{ step }}
-            </li>
+    <section class="cv-section" aria-labelledby="skills-heading">
+        <div class="section-kicker">Skills</div>
+        <h2 id="skills-heading">Technical strengths</h2>
+        <div class="skills-grid">
+            {% for group in cv.skills %}
+            <article class="skill-group">
+                <h3>{{ group.group }}</h3>
+                <ul>
+                    {% for item in group['items'] %}
+                    <li>{{ item }}</li>
+                    {% endfor %}
+                </ul>
+            </article>
             {% endfor %}
-        </ol>
+        </div>
     </section>
 
-    <section class="block about-block">
-        <span class="section-label">{{ landing.about_label }}</span>
-        <p>I'm {{ config.name }}, based in {{ config.location }}. {{ landing.about_body }}</p>
-    </section>
-
-    <section class="block">
-        <span class="section-label">{{ landing.faq_label }}</span>
-        <dl class="faq">
-            {% for item in landing.faq %}
-            <dt>{{ item.q }}</dt>
-            <dd>{{ item.a }}</dd>
+    <section class="cv-section" aria-labelledby="education-heading">
+        <div class="section-kicker">Education and training</div>
+        <h2 id="education-heading">Education</h2>
+        <div class="education-list">
+            {% for item in cv.education %}
+            <article>
+                <h3>{{ item.school }}</h3>
+                <p>{{ item.credential }}</p>
+                <span>{{ item.period }}</span>
+            </article>
             {% endfor %}
-        </dl>
+        </div>
     </section>
 
-    <section class="block cta-block">
-        <h2>{{ landing.closing_heading }}</h2>
-        <p>{{ landing.closing_body }}</p>
-        <div class="cta-row">
-            <a class="btn-primary" href="{{ booking_url }}" target="_blank" rel="noopener noreferrer">
-                {{ landing.cta_label }}<span class="sr-only"> (opens in new tab)</span>
-            </a>
-            <span class="cta-meta">{{ landing.cta_meta_short }}</span>
+    <section class="cv-section cv-contact" aria-labelledby="contact-heading">
+        <div class="section-kicker">Contact</div>
+        <h2 id="contact-heading">{{ cv.contact_heading }}</h2>
+        <p>{{ cv.contact_body }}</p>
+        <div class="cv-actions">
+            <a class="btn-primary" href="mailto:{{ config.email }}">{{ config.email }}</a>
+            {% if config.phone %}
+            <a href="tel:{{ config.phone | replace(' ', '') }}">{{ config.phone }}</a>
+            {% endif %}
         </div>
     </section>
 

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -8,141 +8,113 @@
 {% endblock %}
 
 {% block main_inner %}
-<div class="cv-layout">
+<div class="cv-wrap">
+<div class="cv-card">
 
-    <aside class="cv-sidebar" aria-label="Profile and navigation">
-        <div class="cv-sidebar__inner">
-
-            <div class="cv-sidebar__identity">
-                <h1 class="cv-sidebar__name">{{ config.name }}</h1>
-                <p class="cv-sidebar__role">{{ config.tagline }}</p>
-                <p class="cv-sidebar__location">{{ config.location }}</p>
-            </div>
-
-            <nav class="cv-sidebar__nav" aria-label="Page sections">
-                <a href="#intro">About</a>
-                <a href="#experience">Experience</a>
-                <a href="#skills">Skills</a>
-                <a href="#credits">Studios</a>
-                <a href="#education">Education</a>
-                <a href="#contact">Contact</a>
-            </nav>
-
-            <div class="cv-sidebar__links" aria-label="Contact and profiles">
-                <a href="mailto:{{ config.email }}">{{ config.email }}</a>
-                {% if config.phone %}
-                <a href="tel:{{ config.phone | replace(' ', '') }}">{{ config.phone }}</a>
-                {% endif %}
-                {% if config.linkedin_url %}
-                <a href="{{ config.linkedin_url }}" target="_blank" rel="noopener noreferrer" class="cv-sidebar__social-link">
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                        <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
-                    </svg>
-                    LinkedIn<span class="sr-only"> (opens in new tab)</span>
-                </a>
-                {% endif %}
-                {% if config.github_url %}
-                <a href="{{ config.github_url }}" target="_blank" rel="noopener noreferrer" class="cv-sidebar__social-link">
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                        <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
-                    </svg>
-                    GitHub<span class="sr-only"> (opens in new tab)</span>
-                </a>
-                {% endif %}
-                {% if config.imdb_url %}
-                <a href="{{ config.imdb_url }}" target="_blank" rel="noopener noreferrer">
-                    IMDb<span class="sr-only"> (opens in new tab)</span>
-                </a>
-                {% endif %}
-            </div>
-
+    <!-- ── Header: name + contact ── -->
+    <header class="cv-header">
+        <div class="cv-header__identity">
+            <h1 class="cv-name">{{ config.name }}</h1>
+            <p class="cv-subtitle">{{ config.tagline }}</p>
         </div>
-    </aside>
+        <div class="cv-header__contact" aria-label="Contact details">
+            <a href="mailto:{{ config.email }}">{{ config.email }}</a>
+            {% if config.phone %}
+            <a href="tel:{{ config.phone | replace(' ', '') }}">{{ config.phone }}</a>
+            {% endif %}
+            {% if config.linkedin_url %}
+            <a href="{{ config.linkedin_url }}" target="_blank" rel="noopener noreferrer" class="cv-social-link">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+                LinkedIn<span class="sr-only"> (opens in new tab)</span>
+            </a>
+            {% endif %}
+            {% if config.github_url %}
+            <a href="{{ config.github_url }}" target="_blank" rel="noopener noreferrer" class="cv-social-link">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+                GitHub<span class="sr-only"> (opens in new tab)</span>
+            </a>
+            {% endif %}
+            {% if config.imdb_url %}
+            <a href="{{ config.imdb_url }}" target="_blank" rel="noopener noreferrer">IMDb<span class="sr-only"> (opens in new tab)</span></a>
+            {% endif %}
+            <span class="cv-location">{{ config.location }}</span>
+        </div>
+    </header>
 
-    <div class="cv-main">
+    <!-- ── Body: two columns ── -->
+    <div class="cv-body">
 
-        <section id="intro" class="cv-section cv-intro" aria-label="Introduction">
-            <span class="eyebrow">{{ cv.eyebrow }}</span>
-            <p class="lede">{{ cv.tagline }}</p>
-            <p class="cv-summary">{{ cv.summary }}</p>
-            <ul class="fit-list" aria-label="Role fit">
-                {% for item in cv.fit %}
-                <li>{{ item }}</li>
-                {% endfor %}
-            </ul>
-        </section>
+        <!-- Left column: Education · Skills · Studios -->
+        <aside class="cv-col cv-col--left">
 
-        <section id="experience" class="cv-section" aria-labelledby="experience-heading">
-            <h2 id="experience-heading" class="section-heading">Experience</h2>
-            <div class="timeline">
-                {% for item in cv.experience %}
-                <article class="timeline-item">
-                    <div class="timeline-item__meta">
-                        <span>{{ item.period }}</span>
-                        <span>{{ item.location }}</span>
-                    </div>
-                    <h3 class="timeline-item__role">{{ item.role }}</h3>
-                    <p class="timeline-item__company">{{ item.company }}</p>
-                    <p class="timeline-item__summary">{{ item.summary }}</p>
-                    <ul class="timeline-item__highlights">
-                        {% for highlight in item.highlights %}
-                        <li>{{ highlight }}</li>
-                        {% endfor %}
-                    </ul>
-                </article>
-                {% endfor %}
-            </div>
-        </section>
-
-        <section id="skills" class="cv-section" aria-labelledby="skills-heading">
-            <h2 id="skills-heading" class="section-heading">Skills</h2>
-            <div class="skill-groups">
-                {% for group in cv.skills %}
-                <div class="skill-group">
-                    <h3 class="skill-group__label">{{ group.group }}</h3>
-                    <ul class="skill-chips" role="list">
-                        {% for item in group['items'] %}
-                        <li>{{ item }}</li>
-                        {% endfor %}
-                    </ul>
-                </div>
-                {% endfor %}
-            </div>
-        </section>
-
-        <section id="credits" class="cv-section" aria-labelledby="credits-heading">
-            <h2 id="credits-heading" class="section-heading">Studios</h2>
-            <ul class="credit-chips" role="list">
-                {% for credit in cv.credits %}
-                <li>{{ credit }}</li>
-                {% endfor %}
-            </ul>
-        </section>
-
-        <section id="education" class="cv-section" aria-labelledby="education-heading">
-            <h2 id="education-heading" class="section-heading">Education</h2>
-            <div class="education-list">
+            <section class="cv-section" aria-labelledby="edu-label">
+                <h2 id="edu-label" class="cv-label">Education</h2>
                 {% for item in cv.education %}
-                <article class="education-item">
+                <div class="edu-entry">
                     <h3>{{ item.school }}</h3>
                     <p>{{ item.credential }}</p>
                     <span>{{ item.period }}</span>
+                </div>
+                {% endfor %}
+            </section>
+
+            <section class="cv-section" aria-labelledby="skills-label">
+                <h2 id="skills-label" class="cv-label">Skills</h2>
+                {% for group in cv.skills %}
+                <div class="skill-entry">
+                    <h3>{{ group.group }}</h3>
+                    <p>{{ group['items'] | join(', ') }}</p>
+                </div>
+                {% endfor %}
+            </section>
+
+            <section class="cv-section" aria-labelledby="studios-label">
+                <h2 id="studios-label" class="cv-label">Studios</h2>
+                {% for credit in cv.credits %}
+                <p class="studio-entry">{{ credit }}</p>
+                {% endfor %}
+            </section>
+
+        </aside>
+
+        <!-- Right column: Profile · Experience · Contact -->
+        <div class="cv-col cv-col--right">
+
+            <section class="cv-section" aria-labelledby="profile-label">
+                <h2 id="profile-label" class="cv-label">Profile</h2>
+                <p class="cv-profile-text">{{ cv.summary }}</p>
+            </section>
+
+            <section class="cv-section" aria-labelledby="exp-label">
+                <h2 id="exp-label" class="cv-label">Experience</h2>
+                {% for item in cv.experience %}
+                <article class="exp-item">
+                    <div class="exp-item__header">
+                        <h3 class="exp-item__role">{{ item.role }}</h3>
+                        <span class="exp-item__period">{{ item.period }}</span>
+                    </div>
+                    <p class="exp-item__company">{{ item.company }} &middot; {{ item.location }}</p>
+                    <ul class="exp-item__list">
+                        {% for h in item.highlights %}<li>{{ h }}</li>{% endfor %}
+                    </ul>
                 </article>
                 {% endfor %}
-            </div>
-        </section>
+            </section>
 
-        <section id="contact" class="cv-section cv-contact" aria-labelledby="contact-heading">
-            <h2 id="contact-heading" class="section-heading">{{ cv.contact_heading }}</h2>
-            <p>{{ cv.contact_body }}</p>
-            <div class="cv-cta">
-                <a class="btn-primary" href="mailto:{{ config.email }}">{{ config.email }}</a>
-                {% if config.phone %}
-                <a href="tel:{{ config.phone | replace(' ', '') }}">{{ config.phone }}</a>
-                {% endif %}
-            </div>
-        </section>
+            <section class="cv-section cv-contact-section" aria-labelledby="contact-label">
+                <h2 id="contact-label" class="cv-label">{{ cv.contact_heading }}</h2>
+                <p class="cv-contact-body">{{ cv.contact_body }}</p>
+                <div class="cv-cta">
+                    <a class="btn-primary" href="mailto:{{ config.email }}">{{ config.email }}</a>
+                    {% if config.phone %}
+                    <a class="btn-ghost" href="tel:{{ config.phone | replace(' ', '') }}">{{ config.phone }}</a>
+                    {% endif %}
+                </div>
+            </section>
 
+        </div>
     </div>
+
+</div>
 </div>
 {% endblock %}

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -67,6 +67,16 @@
                 {% endfor %}
             </section>
 
+            <section id="skills" class="cv-section" aria-labelledby="skills-label">
+                <h2 id="skills-label" class="cv-label">Skills</h2>
+                {% for group in cv.skills %}
+                <div class="skill-entry">
+                    <h3>{{ group.group }}</h3>
+                    <p>{{ group['items'] | join(', ') }}</p>
+                </div>
+                {% endfor %}
+            </section>
+
             <section id="contact" class="cv-section cv-contact-section" aria-labelledby="contact-label">
                 <h2 id="contact-label" class="cv-label">{{ cv.contact_heading }}</h2>
                 <p class="cv-contact-body">{{ cv.contact_body }}</p>

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -41,13 +41,23 @@
         </div>
     </header>
 
+    <!-- ── Section nav ── -->
+    <nav class="cv-section-nav" aria-label="Jump to section">
+        <a href="#profile">Profile</a>
+        <a href="#experience">Experience</a>
+        <a href="#skills">Skills</a>
+        <a href="#education">Education</a>
+        <a href="#studios">Studios</a>
+        <a href="#contact">Contact</a>
+    </nav>
+
     <!-- ── Body: two columns ── -->
     <div class="cv-body">
 
         <!-- Left column: Education · Skills · Studios -->
         <aside class="cv-col cv-col--left">
 
-            <section class="cv-section" aria-labelledby="edu-label">
+            <section id="education" class="cv-section" aria-labelledby="edu-label">
                 <h2 id="edu-label" class="cv-label">Education</h2>
                 {% for item in cv.education %}
                 <div class="edu-entry">
@@ -58,7 +68,7 @@
                 {% endfor %}
             </section>
 
-            <section class="cv-section" aria-labelledby="skills-label">
+            <section id="skills" class="cv-section" aria-labelledby="skills-label">
                 <h2 id="skills-label" class="cv-label">Skills</h2>
                 {% for group in cv.skills %}
                 <div class="skill-entry">
@@ -68,7 +78,7 @@
                 {% endfor %}
             </section>
 
-            <section class="cv-section" aria-labelledby="studios-label">
+            <section id="studios" class="cv-section" aria-labelledby="studios-label">
                 <h2 id="studios-label" class="cv-label">Studios</h2>
                 {% for credit in cv.credits %}
                 <p class="studio-entry">{{ credit }}</p>
@@ -80,12 +90,12 @@
         <!-- Right column: Profile · Experience · Contact -->
         <div class="cv-col cv-col--right">
 
-            <section class="cv-section" aria-labelledby="profile-label">
+            <section id="profile" class="cv-section" aria-labelledby="profile-label">
                 <h2 id="profile-label" class="cv-label">Profile</h2>
                 <p class="cv-profile-text">{{ cv.summary }}</p>
             </section>
 
-            <section class="cv-section" aria-labelledby="exp-label">
+            <section id="experience" class="cv-section" aria-labelledby="exp-label">
                 <h2 id="exp-label" class="cv-label">Experience</h2>
                 {% for item in cv.experience %}
                 <article class="exp-item">
@@ -101,7 +111,7 @@
                 {% endfor %}
             </section>
 
-            <section class="cv-section cv-contact-section" aria-labelledby="contact-label">
+            <section id="contact" class="cv-section cv-contact-section" aria-labelledby="contact-label">
                 <h2 id="contact-label" class="cv-label">{{ cv.contact_heading }}</h2>
                 <p class="cv-contact-body">{{ cv.contact_body }}</p>
                 <div class="cv-cta">

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -16,6 +16,10 @@
         <div class="cv-header__identity">
             <h1 class="cv-name">{{ config.name }}</h1>
             <p class="cv-subtitle">{{ config.tagline }}</p>
+            <span class="cv-availability">
+                <span class="cv-availability__dot" aria-hidden="true"></span>
+                Available for work
+            </span>
         </div>
         <div class="cv-header__contact" aria-label="Contact details">
             <a href="mailto:{{ config.email }}">{{ config.email }}</a>

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -34,12 +34,18 @@
                 <a href="tel:{{ config.phone | replace(' ', '') }}">{{ config.phone }}</a>
                 {% endif %}
                 {% if config.linkedin_url %}
-                <a href="{{ config.linkedin_url }}" target="_blank" rel="noopener noreferrer">
+                <a href="{{ config.linkedin_url }}" target="_blank" rel="noopener noreferrer" class="cv-sidebar__social-link">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                        <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
+                    </svg>
                     LinkedIn<span class="sr-only"> (opens in new tab)</span>
                 </a>
                 {% endif %}
                 {% if config.github_url %}
-                <a href="{{ config.github_url }}" target="_blank" rel="noopener noreferrer">
+                <a href="{{ config.github_url }}" target="_blank" rel="noopener noreferrer" class="cv-sidebar__social-link">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                        <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
+                    </svg>
                     GitHub<span class="sr-only"> (opens in new tab)</span>
                 </a>
                 {% endif %}

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -8,25 +8,35 @@
 {% endblock %}
 
 {% block main_inner %}
-<div class="page cv-page">
+<div class="cv-layout">
 
-    <section class="cv-hero" aria-labelledby="cv-title">
-        <div class="cv-hero__content">
-            <span class="eyebrow">{{ cv.eyebrow }}</span>
-            <h1 id="cv-title">{{ config.name }}</h1>
-            <p class="cv-title">{{ config.tagline }}</p>
-            <p class="lede">{{ cv.tagline }}</p>
-            <p class="cv-summary">{{ cv.summary }}</p>
+    <aside class="cv-sidebar" aria-label="Profile and navigation">
+        <div class="cv-sidebar__inner">
 
-            <div class="cv-actions" aria-label="Contact and profile links">
-                <a class="btn-primary" href="mailto:{{ config.email }}">Email me</a>
+            <div class="cv-sidebar__identity">
+                <h1 class="cv-sidebar__name">{{ config.name }}</h1>
+                <p class="cv-sidebar__role">{{ config.tagline }}</p>
+                <p class="cv-sidebar__location">{{ config.location }}</p>
+            </div>
+
+            <nav class="cv-sidebar__nav" aria-label="Page sections">
+                <a href="#intro">About</a>
+                <a href="#experience">Experience</a>
+                <a href="#skills">Skills</a>
+                <a href="#credits">Studios</a>
+                <a href="#education">Education</a>
+                <a href="#contact">Contact</a>
+            </nav>
+
+            <div class="cv-sidebar__links" aria-label="Contact and profiles">
+                <a href="mailto:{{ config.email }}">{{ config.email }}</a>
+                {% if config.phone %}
+                <a href="tel:{{ config.phone | replace(' ', '') }}">{{ config.phone }}</a>
+                {% endif %}
                 {% if config.linkedin_url %}
                 <a href="{{ config.linkedin_url }}" target="_blank" rel="noopener noreferrer">
                     LinkedIn<span class="sr-only"> (opens in new tab)</span>
                 </a>
-                {% endif %}
-                {% if config.phone %}
-                <a href="tel:{{ config.phone | replace(' ', '') }}">{{ config.phone }}</a>
                 {% endif %}
                 {% if config.github_url %}
                 <a href="{{ config.github_url }}" target="_blank" rel="noopener noreferrer">
@@ -39,112 +49,94 @@
                 </a>
                 {% endif %}
             </div>
+
         </div>
+    </aside>
 
-        <aside class="cv-snapshot" aria-label="Professional snapshot">
-            <dl>
-                <div>
-                    <dt>Based in</dt>
-                    <dd>{{ config.location }}</dd>
-                </div>
-                <div>
-                    <dt>Focus</dt>
-                    <dd>Python tooling, pipeline workflows, production support</dd>
-                </div>
-                <div>
-                    <dt>Open to</dt>
-                    <dd>Industry and adjacent technical roles</dd>
-                </div>
-            </dl>
-        </aside>
-    </section>
+    <div class="cv-main">
 
-    <section class="cv-section" aria-labelledby="fit-heading">
-        <div class="section-kicker">Role fit</div>
-        <h2 id="fit-heading">Where this profile fits</h2>
-        <ul class="fit-list">
-            {% for item in cv.fit %}
-            <li>{{ item }}</li>
-            {% endfor %}
-        </ul>
-    </section>
+        <section id="intro" class="cv-section cv-intro" aria-label="Introduction">
+            <span class="eyebrow">{{ cv.eyebrow }}</span>
+            <p class="lede">{{ cv.tagline }}</p>
+            <p class="cv-summary">{{ cv.summary }}</p>
+            <ul class="fit-list" aria-label="Role fit">
+                {% for item in cv.fit %}
+                <li>{{ item }}</li>
+                {% endfor %}
+            </ul>
+        </section>
 
-    <section class="cv-section" aria-labelledby="experience-heading">
-        <div class="section-kicker">Experience</div>
-        <h2 id="experience-heading">Recent work</h2>
-        <div class="experience-list">
-            {% for item in cv.experience %}
-            <article class="experience-item">
-                <header>
-                    <div>
-                        <h3>{{ item.role }}</h3>
-                        <p>{{ item.company }}</p>
+        <section id="experience" class="cv-section" aria-labelledby="experience-heading">
+            <h2 id="experience-heading" class="section-heading">Experience</h2>
+            <div class="timeline">
+                {% for item in cv.experience %}
+                <article class="timeline-item">
+                    <div class="timeline-item__meta">
+                        <span>{{ item.period }}</span>
+                        <span>{{ item.location }}</span>
                     </div>
-                    <p class="experience-meta">{{ item.period }} · {{ item.location }}</p>
-                </header>
-                <p>{{ item.summary }}</p>
-                <ul>
-                    {% for highlight in item.highlights %}
-                    <li>{{ highlight }}</li>
-                    {% endfor %}
-                </ul>
-            </article>
-            {% endfor %}
-        </div>
-    </section>
+                    <h3 class="timeline-item__role">{{ item.role }}</h3>
+                    <p class="timeline-item__company">{{ item.company }}</p>
+                    <p class="timeline-item__summary">{{ item.summary }}</p>
+                    <ul class="timeline-item__highlights">
+                        {% for highlight in item.highlights %}
+                        <li>{{ highlight }}</li>
+                        {% endfor %}
+                    </ul>
+                </article>
+                {% endfor %}
+            </div>
+        </section>
 
-    <section class="cv-section" aria-labelledby="credits-heading">
-        <div class="section-kicker">Production context</div>
-        <h2 id="credits-heading">Studios and collaborators</h2>
-        <ul class="credit-list">
-            {% for credit in cv.credits %}
-            <li>{{ credit }}</li>
-            {% endfor %}
-        </ul>
-    </section>
+        <section id="skills" class="cv-section" aria-labelledby="skills-heading">
+            <h2 id="skills-heading" class="section-heading">Skills</h2>
+            <div class="skill-groups">
+                {% for group in cv.skills %}
+                <div class="skill-group">
+                    <h3 class="skill-group__label">{{ group.group }}</h3>
+                    <ul class="skill-chips" role="list">
+                        {% for item in group['items'] %}
+                        <li>{{ item }}</li>
+                        {% endfor %}
+                    </ul>
+                </div>
+                {% endfor %}
+            </div>
+        </section>
 
-    <section class="cv-section" aria-labelledby="skills-heading">
-        <div class="section-kicker">Skills</div>
-        <h2 id="skills-heading">Technical strengths</h2>
-        <div class="skills-grid">
-            {% for group in cv.skills %}
-            <article class="skill-group">
-                <h3>{{ group.group }}</h3>
-                <ul>
-                    {% for item in group['items'] %}
-                    <li>{{ item }}</li>
-                    {% endfor %}
-                </ul>
-            </article>
-            {% endfor %}
-        </div>
-    </section>
+        <section id="credits" class="cv-section" aria-labelledby="credits-heading">
+            <h2 id="credits-heading" class="section-heading">Studios</h2>
+            <ul class="credit-chips" role="list">
+                {% for credit in cv.credits %}
+                <li>{{ credit }}</li>
+                {% endfor %}
+            </ul>
+        </section>
 
-    <section class="cv-section" aria-labelledby="education-heading">
-        <div class="section-kicker">Education and training</div>
-        <h2 id="education-heading">Education</h2>
-        <div class="education-list">
-            {% for item in cv.education %}
-            <article>
-                <h3>{{ item.school }}</h3>
-                <p>{{ item.credential }}</p>
-                <span>{{ item.period }}</span>
-            </article>
-            {% endfor %}
-        </div>
-    </section>
+        <section id="education" class="cv-section" aria-labelledby="education-heading">
+            <h2 id="education-heading" class="section-heading">Education</h2>
+            <div class="education-list">
+                {% for item in cv.education %}
+                <article class="education-item">
+                    <h3>{{ item.school }}</h3>
+                    <p>{{ item.credential }}</p>
+                    <span>{{ item.period }}</span>
+                </article>
+                {% endfor %}
+            </div>
+        </section>
 
-    <section class="cv-section cv-contact" aria-labelledby="contact-heading">
-        <div class="section-kicker">Contact</div>
-        <h2 id="contact-heading">{{ cv.contact_heading }}</h2>
-        <p>{{ cv.contact_body }}</p>
-        <div class="cv-actions">
-            <a class="btn-primary" href="mailto:{{ config.email }}">{{ config.email }}</a>
-            {% if config.phone %}
-            <a href="tel:{{ config.phone | replace(' ', '') }}">{{ config.phone }}</a>
-            {% endif %}
-        </div>
-    </section>
+        <section id="contact" class="cv-section cv-contact" aria-labelledby="contact-heading">
+            <h2 id="contact-heading" class="section-heading">{{ cv.contact_heading }}</h2>
+            <p>{{ cv.contact_body }}</p>
+            <div class="cv-cta">
+                <a class="btn-primary" href="mailto:{{ config.email }}">{{ config.email }}</a>
+                {% if config.phone %}
+                <a href="tel:{{ config.phone | replace(' ', '') }}">{{ config.phone }}</a>
+                {% endif %}
+            </div>
+        </section>
 
+    </div>
 </div>
 {% endblock %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -16,7 +16,7 @@ def test_home_page_content(client):
     assert b'Python tooling' in response.data
     assert b'DNEG' in response.data
     assert b'Blizzard Entertainment' in response.data
-    assert b'Walt Disney Animation Studios' in response.data
+    assert b'Boulder Media' in response.data
     assert b'1:1 game development mentoring' not in response.data
     assert b'Tally' not in response.data
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,21 +2,31 @@ from blog import load_posts
 
 
 def test_home_page(client):
-    """Home page loads the coming soon landing page."""
+    """Home page loads the CV site."""
     response = client.get('/')
     assert response.status_code == 200
     assert b'Sreyeesh Garimella' in response.data
 
 
-def test_home_page_content(client, monkeypatch):
-    """Coming-soon page shows CV/portfolio content when gate is enabled."""
-    monkeypatch.setenv('SITE_COMING_SOON', 'true')
+def test_home_page_content(client):
+    """CV page shows the real positioning and core CV content."""
     response = client.get('/')
     assert b'Sreyeesh Garimella' in response.data
     assert b'Pipeline TD' in response.data
-    assert b'Production Tech Portfolio' in response.data
-    assert b'Render Operations' in response.data
+    assert b'Python tooling' in response.data
+    assert b'DNEG' in response.data
+    assert b'Blizzard Entertainment' in response.data
+    assert b'Walt Disney Animation Studios' in response.data
     assert b'1:1 game development mentoring' not in response.data
+    assert b'Tally' not in response.data
+
+
+def test_home_page_ignores_legacy_coming_soon_flag(client, monkeypatch):
+    """The old coming-soon gate must not replace the CV homepage."""
+    monkeypatch.setenv('SITE_COMING_SOON', 'true')
+    response = client.get('/')
+    assert b'Pipeline TD and Software Developer' in response.data
+    assert b'Get launch updates' not in response.data
 
 
 def test_home_page_has_og_image(client):
@@ -39,6 +49,14 @@ def test_pages_load(client):
     """Blog index renders the post list."""
     response = client.get('/blog/')
     assert response.status_code == 200
+
+
+def test_about_page_uses_cv_bio(client):
+    response = client.get('/about/')
+    assert response.status_code == 200
+    assert b'Pipeline TD and software developer' in response.data
+    assert b'DNEG' in response.data
+    assert b'Book a session' not in response.data
 
 
 def test_sitemap_endpoint(client):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -16,7 +16,7 @@ def test_home_page_content(client):
     assert b'Python tooling' in response.data
     assert b'DNEG' in response.data
     assert b'Blizzard Entertainment' in response.data
-    assert b'Boulder Media' in response.data
+    assert b'Walt Disney Animation Studios' in response.data
     assert b'1:1 game development mentoring' not in response.data
     assert b'Tally' not in response.data
 


### PR DESCRIPTION
## Summary
- Replace the mentoring landing page with a data-driven CV homepage using the provided CV content
- Remove the legacy coming-soon gate from the primary public routes
- Rewrite About page around professional CV positioning
- Add regression coverage for CV content and absence of old signup/booking copy

## Verification
- make test
- docker compose run --rm tests flake8 app.py tests/test_app.py
- SITE_URL=https://toucan.ee SITE_COMING_SOON=true python freeze.py inside the tests container
- git diff --check

Part of #221