### PR TITLE
feat(nav): active state for current page nav link

### DIFF
--- a/app.py
+++ b/app.py
@@ -42,9 +42,9 @@ SITE_CONFIG = {
 }
 
 NAV_LINKS = [
-    {'label': 'Home', 'href': '/'},
-    {'label': 'Writing', 'href': '/blog/'},
-    {'label': 'About', 'href': '/about/'},
+    {'label': 'Home', 'href': '/', 'slug': 'home'},
+    {'label': 'Writing', 'href': '/blog/', 'slug': 'blog'},
+    {'label': 'About', 'href': '/about/', 'slug': 'about'},
 ]
 
 SITE_LINKS = {

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -183,6 +183,7 @@ code, pre {
 }
 
 .nav-links a:hover { color: var(--text); opacity: 1; }
+.nav-links .nav-link--active { color: var(--text); font-weight: 500; }
 .nav-links .nav-link--cta { all: unset; font-family: system-ui, -apple-system, sans-serif; font-size: 0.875rem; color: var(--text-muted); cursor: pointer; }
 .nav-links .nav-link--cta:hover { color: var(--text); }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -53,7 +53,8 @@
             <div class="nav-links" id="nav-links">
                 {% for item in nav_links %}
                     <a href="{{ item.href }}"
-                        class="{% if item.is_cta %}nav-link--cta{% endif %}">
+                        class="{% if item.is_cta %}nav-link--cta{% endif %}{% if item.slug == page_slug %} nav-link--active{% endif %}"
+                        {% if item.slug == page_slug %}aria-current="page"{% endif %}>
                         {{ item.label }}
                     </a>
                 {% endfor %}


### PR DESCRIPTION
## Summary

- Added `slug` key to each entry in `NAV_LINKS`
- Template applies `nav-link--active` class and `aria-current="page"` when the link slug matches the current `page_slug`
- Active link gets `color: var(--text)` and `font-weight: 500` so it's visually distinct without being heavy

Closes #172