### PR TITLE
feat(cv): IMDb profile link + CV header and layout improvements

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,42 @@
+# Product
+
+## Register
+
+brand
+
+## Users
+
+Primary: VFX and animation studio hiring managers, pipeline supervisors, and technical directors evaluating a Pipeline TD or Production Technology Specialist candidate. They've been sent this URL and are scanning quickly for signal — real credits, technical depth, communication quality. They know what a pipeline person should know and will notice the difference between someone who sounds competent and someone who is.
+
+Secondary: aspiring animation and game developers considering 1-on-1 mentoring. Less urgent now — the site is actively shifting toward job-hunting mode.
+
+## Product Purpose
+
+Establish Sreyeesh Garimella as a credible, senior-level Pipeline TD candidate with serious production experience across Disney, Blizzard, DNEG, and others. Surface that experience clearly and let it do the persuading. The site should feel like it was built by someone who cares about craft and organization — which is exactly what hiring managers want in a pipeline person.
+
+Success: a studio contact views the site and immediately understands what Sreyeesh does, what he has shipped, and why they should reach out.
+
+## Brand Personality
+
+Quiet and precise. Confident without selling. Expertise proven through clarity, not claims. The kind of professional presence that doesn't need to convince you — the credits and consistency do the work.
+
+Three words: **precise, experienced, legible**
+
+## Anti-references
+
+- **Generic SaaS landing page:** hero metric cards, gradient text, identical icon grids, fake urgency banners ("Limited Availability"), conversion-optimized copy. The current index.html has this problem.
+- **Over-designed portfolio:** flashy scroll animations, WebGL backgrounds, cursor effects, parallax. Trying too hard, distracting from the work.
+- **Resume dumped on a page:** just a PDF translated to HTML with no organization or personality — sterile and forgettable.
+- **Creative agency aesthetic:** full-bleed imagery, big serif headlines, art-directed editorial layout. More for visual designers than Pipeline TDs.
+
+## Design Principles
+
+1. **Show, don't sell.** No urgency copy, no conversion tricks, no "Limited Availability" banners. Real credits at real studios persuade hiring managers; sales tactics repel them.
+2. **Expertise through clarity.** Organized, scannable information hierarchy signals technical competence. A Pipeline TD who can write clear docs and structure a system clearly is exactly what studios want.
+3. **Confidence without performance.** The person is the signal. No hero animations, no decorative chrome. Design should recede so the work comes forward.
+4. **Pipeline TD aesthetic.** The site should look like something a thoughtful technical person built — systematic, functional, uncluttered. Not a developer's default Bootstrap page, but not an art director's showpiece either.
+5. **Content before chrome.** Typography, spacing, and hierarchy matter more than color, illustration, or motion.
+
+## Accessibility & Inclusion
+
+WCAG AA minimum. Reduced motion already respected in base.css. Dark mode supported. Standard contrast ratios for body text and interactive elements.

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -3,27 +3,27 @@
 
 /* Variables */
 :root {
-    --bg: #fafaf8;
-    --text: #1a1a1a;
-    --text-muted: #6b6b6b;
-    --accent: #0f62fe;
-    --border: #e0e0de;
-    --nav-bg: rgba(250, 250, 248, 0.95);
+    --bg: oklch(98.5% 0.006 80);
+    --text: oklch(16% 0.012 60);
+    --text-muted: oklch(52% 0.01 65);
+    --accent: oklch(54% 0.19 47);
+    --border: oklch(89% 0.008 75);
+    --nav-bg: oklch(98.5% 0.006 80 / 0.95);
     --wrap-width: 700px;
     --nav-height: 56px;
-    --font-sans: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
-    --font-serif: 'Inter', system-ui, -apple-system, sans-serif;
-    --font-body: 'Inter', system-ui, -apple-system, sans-serif;
+    --font-sans: 'Barlow', system-ui, -apple-system, sans-serif;
+    --font-serif: 'Barlow Condensed', system-ui, sans-serif;
+    --font-body: 'Barlow', system-ui, -apple-system, sans-serif;
     --font-mono: 'JetBrains Mono', 'SFMono-Regular', Menlo, monospace;
 }
 
 html[data-theme="dark"] {
-    --bg: #111111;
-    --text: #d4d4d4;
-    --text-muted: #888;
-    --accent: #6aafff;
-    --border: rgba(255, 255, 255, 0.1);
-    --nav-bg: rgba(17, 17, 17, 0.95);
+    --bg: oklch(13% 0.008 60);
+    --text: oklch(84% 0.012 70);
+    --text-muted: oklch(58% 0.012 65);
+    --accent: oklch(72% 0.17 52);
+    --border: oklch(28% 0.01 60 / 0.7);
+    --nav-bg: oklch(13% 0.008 60 / 0.95);
 }
 
 html { scroll-behavior: smooth; }
@@ -111,11 +111,13 @@ p { max-width: 68ch; line-height: 1.8; }
 
 h1, h2, h3, h4 {
     font-family: var(--font-serif);
-    font-weight: 600;
-    line-height: 1.2;
-    letter-spacing: -0.02em;
+    font-weight: 700;
+    line-height: 1.1;
+    letter-spacing: -0.01em;
     overflow-wrap: break-word;
 }
+
+h1 { font-weight: 800; }
 
 code, pre {
     font-family: var(--font-mono);

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -158,15 +158,20 @@ code, pre {
 .nav-brand { display: flex; align-items: center; }
 
 .nav-name-link {
-    font-family: var(--font-sans);
-    font-size: 0.95rem;
-    font-weight: 500;
-    color: var(--text);
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--text-muted);
     text-decoration: none;
-    letter-spacing: -0.01em;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    transition: color 0.12s;
 }
 
-.nav-name-link:hover { opacity: 0.7; }
+.nav-name-link:hover {
+    color: var(--accent);
+    opacity: 1;
+}
 
 .nav-tagline { display: none; }
 

--- a/static/css/components-core.css
+++ b/static/css/components-core.css
@@ -86,35 +86,16 @@
     outline-offset: 3px;
 }
 
-/* Enhanced CTA Buttons - Professional Gradient Design */
 .primary-cta {
-    background: linear-gradient(135deg, #0f62fe, #06c0f6);
+    background: var(--accent);
     color: #fff;
     border: none;
-    box-shadow: 0 25px 45px rgba(15, 98, 254, 0.35);
-    position: relative;
-    overflow: hidden;
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
-}
-
-.primary-cta::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: -100%;
-    width: 100%;
-    height: 100%;
-    background: linear-gradient(90deg, transparent, rgba(255,255,255,0.2), transparent);
-    transition: left 0.5s;
-}
-
-.primary-cta:hover::before {
-    left: 100%;
+    box-shadow: 0 6px 20px oklch(54% 0.19 47 / 0.3);
 }
 
 .primary-cta:hover {
-    transform: translateY(-3px);
-    box-shadow: 0 12px 35px rgba(102, 126, 234, 0.4);
+    transform: translateY(-2px);
+    box-shadow: 0 10px 28px oklch(54% 0.19 47 / 0.4);
 }
 
 /* Secondary CTA Button - Outline style */
@@ -183,9 +164,9 @@ section h2 {
 .current-status {
     margin-top: 20px;
     padding: 15px;
-    background: var(--bg-primary);
+    background: var(--bg);
     border-radius: 8px;
-    border-left: 4px solid #10b981;
+    border: 1px solid var(--border);
 }
 
 .current-status p {
@@ -647,7 +628,7 @@ section h2 {
     background: var(--bg-primary, #ffffff);
     color: var(--text-primary, #333333);
     transition: all 0.3s ease;
-    font-family: 'Inter', sans-serif;
+    font-family: var(--font-sans);
 }
 
 .form-group input:focus,
@@ -715,38 +696,21 @@ section h2 {
 .submit-button {
     width: 100%;
     padding: 16px 24px;
-    background: linear-gradient(135deg, var(--accent-primary, #667eea) 0%, var(--accent-secondary, #764ba2) 100%);
+    background: var(--accent);
     color: white;
     border: none;
     border-radius: 8px;
     font-size: 16px;
     font-weight: 600;
     cursor: pointer;
-    transition: all 0.3s ease;
-    font-family: 'Inter', sans-serif;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    font-family: var(--font-sans);
     letter-spacing: 0.5px;
-    position: relative;
-    overflow: hidden;
-}
-
-.submit-button::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: -100%;
-    width: 100%;
-    height: 100%;
-    background: linear-gradient(90deg, transparent, rgba(255,255,255,0.2), transparent);
-    transition: left 0.5s;
-}
-
-.submit-button:hover::before {
-    left: 100%;
 }
 
 .submit-button:hover {
     transform: translateY(-2px);
-    box-shadow: 0 8px 25px rgba(102, 126, 234, 0.3);
+    box-shadow: 0 8px 24px oklch(54% 0.19 47 / 0.3);
 }
 
 .submit-button:active {
@@ -1328,10 +1292,10 @@ section h2 {
 
 .home-intro h1 {
     font-family: var(--font-serif);
-    font-size: clamp(2rem, 5vw, 2.75rem);
-    font-weight: 600;
-    letter-spacing: -0.03em;
-    line-height: 1.1;
+    font-size: clamp(2.75rem, 6vw, 4rem);
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    line-height: 1.05;
     margin-bottom: 1.25rem;
 }
 
@@ -1385,10 +1349,10 @@ section h2 {
 
 .about-header h1 {
     font-family: var(--font-serif);
-    font-size: clamp(2rem, 5vw, 2.75rem);
-    font-weight: 600;
-    letter-spacing: -0.03em;
-    line-height: 1.1;
+    font-size: clamp(3.5rem, 9vw, 5.5rem);
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    line-height: 1.0;
 }
 
 .about-body p {
@@ -1408,11 +1372,11 @@ section h2 {
 .about-body h2,
 .about-links h2 {
     font-family: var(--font-serif);
-    font-size: 1.15rem;
-    font-weight: 600;
+    font-size: clamp(1.3rem, 3vw, 1.6rem);
+    font-weight: 700;
     letter-spacing: -0.01em;
-    margin-top: 2rem;
-    margin-bottom: 1rem;
+    margin-top: 2.5rem;
+    margin-bottom: 0.9rem;
 }
 
 .about-body a {

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -1,74 +1,79 @@
 @import url('base.css');
 
-/* ── Smooth scrolling ────────────────────── */
-
-html {
-    scroll-behavior: smooth;
-}
-
 /* ── Page background ─────────────────────── */
 
 .cv-page-main {
-    padding: 3rem 1.5rem 5rem;
-    background: #e8e6e0;
+    padding: 3rem 1.5rem 6rem;
+    background: oklch(88% 0.01 75);
 }
 
 [data-theme="dark"] .cv-page-main {
-    background: #0d0d0d;
+    background: oklch(9% 0.01 55);
 }
 
 /* ── Card wrapper ────────────────────────── */
 
 .cv-wrap {
-    max-width: 980px;
+    max-width: 1040px;
     margin: 0 auto;
 }
 
 .cv-card {
     background: var(--bg);
-    border-radius: 4px;
-    box-shadow: 0 4px 40px rgba(0, 0, 0, 0.12);
+    border-radius: 6px;
+    box-shadow: 0 1px 3px oklch(0% 0 0 / 0.08), 0 8px 32px oklch(0% 0 0 / 0.1);
     overflow: hidden;
 }
 
 [data-theme="dark"] .cv-card {
-    box-shadow: 0 4px 40px rgba(0, 0, 0, 0.5);
+    background: oklch(16% 0.009 58);
+    box-shadow: 0 4px 48px oklch(0% 0 0 / 0.6);
 }
 
 /* ── Header ──────────────────────────────── */
 
 .cv-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: start;
     gap: 2rem;
-    padding: 2.25rem 2.5rem;
-    border-bottom: 2px solid var(--text);
+    padding: 3rem 3rem 2.5rem;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg);
+}
+
+[data-theme="dark"] .cv-header {
+    background: oklch(14% 0.01 58);
+    border-bottom-color: oklch(30% 0.01 58);
 }
 
 .cv-name {
-    font-size: clamp(1.6rem, 4vw, 2.5rem);
-    font-weight: 700;
-    letter-spacing: 0.06em;
+    font-family: var(--font-serif);
+    font-size: clamp(3rem, 7vw, 5.5rem);
+    font-weight: 800;
+    letter-spacing: 0.04em;
     text-transform: uppercase;
-    line-height: 1.1;
+    line-height: 0.95;
     color: var(--text);
 }
 
 .cv-subtitle {
-    margin-top: 0.35rem;
+    margin-top: 0.75rem;
     color: var(--text-muted);
+    font-family: var(--font-sans);
     font-size: 0.875rem;
     font-weight: 400;
-    letter-spacing: 0.02em;
-    line-height: 1.4;
+    letter-spacing: 0.03em;
+    line-height: 1.55;
+    max-width: 48ch;
 }
 
 .cv-header__contact {
     display: flex;
     flex-direction: column;
     align-items: flex-end;
-    gap: 0.35rem;
+    gap: 0.4rem;
+    padding-top: 0.35rem;
     flex-shrink: 0;
 }
 
@@ -76,9 +81,9 @@ html {
 .cv-location {
     color: var(--text-muted);
     font-family: var(--font-mono);
-    font-size: 0.72rem;
+    font-size: 0.7rem;
     text-decoration: none;
-    letter-spacing: 0.02em;
+    letter-spacing: 0.03em;
     transition: color 0.12s;
 }
 
@@ -96,40 +101,41 @@ html {
 .cv-availability {
     display: inline-flex;
     align-items: center;
-    gap: 0.4rem;
-    margin-top: 0.65rem;
-    padding: 0.3rem 0.75rem 0.3rem 0.55rem;
+    gap: 0.45rem;
+    margin-top: 1rem;
+    padding: 0.32rem 0.85rem 0.32rem 0.65rem;
     border-radius: 999px;
-    border: 1px solid rgba(34, 197, 94, 0.35);
-    background: rgba(34, 197, 94, 0.08);
-    color: #16a34a;
-    font-size: 0.72rem;
-    font-weight: 500;
-    letter-spacing: 0.03em;
+    border: 1px solid oklch(52% 0.18 145 / 0.3);
+    background: oklch(52% 0.18 145 / 0.06);
+    color: oklch(40% 0.18 145);
+    font-family: var(--font-sans);
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
 }
 
 [data-theme="dark"] .cv-availability {
-    color: #4ade80;
-    background: rgba(74, 222, 128, 0.08);
-    border-color: rgba(74, 222, 128, 0.25);
+    color: oklch(70% 0.18 145);
+    background: oklch(52% 0.18 145 / 0.1);
+    border-color: oklch(52% 0.18 145 / 0.28);
 }
 
 .cv-availability__dot {
-    width: 7px;
-    height: 7px;
+    width: 6px;
+    height: 6px;
     border-radius: 50%;
-    background: #16a34a;
+    background: oklch(50% 0.18 145);
     flex-shrink: 0;
     animation: pulse-dot 2.5s ease-in-out infinite;
 }
 
 [data-theme="dark"] .cv-availability__dot {
-    background: #4ade80;
+    background: oklch(68% 0.18 145);
 }
 
 @keyframes pulse-dot {
     0%, 100% { opacity: 1; transform: scale(1); }
-    50%       { opacity: 0.5; transform: scale(0.75); }
+    50%       { opacity: 0.4; transform: scale(0.7); }
 }
 
 .cv-social-link {
@@ -140,9 +146,8 @@ html {
 
 .cv-social-link svg {
     flex-shrink: 0;
-    opacity: 0.65;
+    opacity: 0.6;
 }
-
 
 /* ── Scroll offset for fixed nav ─────────── */
 
@@ -153,15 +158,30 @@ html {
 /* ── Body ────────────────────────────────── */
 
 .cv-body {
-    padding: 2.5rem 3rem;
-    max-width: 780px;
-    margin: 0 auto;
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    align-items: start;
+}
+
+.cv-sidebar {
+    padding: 2.75rem 2rem 3.5rem 3rem;
+    border-right: 1px solid var(--border);
+    min-height: 100%;
+}
+
+[data-theme="dark"] .cv-sidebar {
+    background: oklch(14.5% 0.009 58);
+    border-right-color: oklch(28% 0.01 58);
+}
+
+.cv-main {
+    padding: 2.75rem 3rem 3.5rem 2.5rem;
 }
 
 /* ── Section ─────────────────────────────── */
 
 .cv-section {
-    margin-bottom: 2rem;
+    margin-bottom: 2.75rem;
 }
 
 .cv-section:last-child {
@@ -171,45 +191,24 @@ html {
 /* ── Section label ───────────────────────── */
 
 .cv-label {
-    margin-bottom: 1rem;
-    padding-bottom: 0.35rem;
-    border-bottom: 1.5px solid var(--text);
-    color: var(--text);
-    font-size: 0.7rem;
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin-bottom: 1.1rem;
+    color: var(--accent);
+    font-family: var(--font-serif);
+    font-size: 0.6rem;
     font-weight: 700;
-    letter-spacing: 0.12em;
+    letter-spacing: 0.18em;
     text-transform: uppercase;
     line-height: 1.4;
 }
 
-
-/* ── Skills ──────────────────────────────── */
-
-.skill-entry {
-    display: grid;
-    grid-template-columns: 180px 1fr;
-    gap: 0.5rem 1.5rem;
-    padding: 0.6rem 0;
-    border-bottom: 1px solid var(--border);
-    align-items: baseline;
-}
-
-.skill-entry:last-child {
-    border-bottom: none;
-}
-
-.skill-entry h3 {
-    color: var(--text-muted);
-    font-size: 0.72rem;
-    font-weight: 600;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-}
-
-.skill-entry p {
-    color: var(--text);
-    font-size: 0.85rem;
-    line-height: 1.55;
+.cv-label::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: var(--border);
 }
 
 /* ── Profile ─────────────────────────────── */
@@ -217,70 +216,175 @@ html {
 #profile.cv-section {
     padding-bottom: 2.5rem;
     margin-bottom: 2.5rem;
+    border-bottom: 1px solid var(--border);
 }
 
 .cv-profile-text {
     color: var(--text);
-    font-size: 1.05rem;
+    font-size: 1rem;
     font-weight: 400;
-    line-height: 1.8;
-    max-width: 62ch;
+    line-height: 1.88;
+    max-width: 66ch;
 }
 
-/* ── Experience ──────────────────────────── */
+/* ── Experience cards ────────────────────── */
 
 .exp-item {
-    margin-bottom: 1.75rem;
-    padding-bottom: 1.75rem;
-    border-bottom: 1px solid var(--border);
+    border: 1px solid var(--border);
+    border-top: 2px solid var(--accent);
+    border-radius: 5px;
+    margin-bottom: 0.875rem;
+    overflow: hidden;
+    transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+[data-theme="dark"] .exp-item {
+    background: oklch(18% 0.009 58);
 }
 
 .exp-item:last-child {
     margin-bottom: 0;
-    padding-bottom: 0;
-    border-bottom: none;
 }
 
-.exp-item__header {
+.exp-item:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 24px oklch(0% 0 0 / 0.15);
+    border-top-color: var(--accent);
+}
+
+[data-theme="dark"] .exp-item:hover {
+    box-shadow: 0 8px 32px oklch(0% 0 0 / 0.4);
+}
+
+.exp-item__card-header {
     display: flex;
     justify-content: space-between;
-    align-items: baseline;
+    align-items: flex-start;
     gap: 1rem;
-    margin-bottom: 0.2rem;
+    padding: 1rem 1.35rem 0.85rem;
+    background: oklch(97% 0.004 75);
+    border-bottom: 1px solid var(--border);
+}
+
+[data-theme="dark"] .exp-item__card-header {
+    background: oklch(21% 0.01 58);
+    border-bottom-color: oklch(28% 0.01 58);
+}
+
+.exp-item__identity {
+    min-width: 0;
+}
+
+.exp-item__company {
+    font-family: var(--font-serif);
+    font-size: 1.05rem;
+    font-weight: 800;
+    color: var(--text);
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    line-height: 1.15;
 }
 
 .exp-item__role {
-    color: var(--text);
-    font-size: 0.9rem;
-    font-weight: 600;
-    line-height: 1.35;
+    margin-top: 0.3rem;
+    color: var(--accent);
+    font-family: var(--font-sans);
+    font-size: 0.8rem;
+    font-weight: 500;
+    line-height: 1.4;
+    letter-spacing: 0.01em;
+}
+
+.exp-item__meta {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.2rem;
+    flex-shrink: 0;
+    padding-top: 0.1rem;
 }
 
 .exp-item__period {
-    flex-shrink: 0;
     color: var(--text-muted);
     font-family: var(--font-mono);
-    font-size: 0.67rem;
-    letter-spacing: 0.05em;
+    font-size: 0.63rem;
+    letter-spacing: 0.06em;
     text-transform: uppercase;
     white-space: nowrap;
 }
 
-.exp-item__company {
+.exp-item__location {
     color: var(--text-muted);
-    font-size: 0.8rem;
-    font-style: italic;
-    margin-bottom: 0.55rem;
+    font-size: 0.65rem;
+    white-space: nowrap;
+    opacity: 0.7;
+    font-family: var(--font-mono);
 }
 
 .exp-item__list {
-    padding-left: 1.1rem;
     margin: 0;
+    padding: 0.85rem 1.35rem 1rem 2.25rem;
     display: grid;
-    gap: 0.3rem;
+    gap: 0.35rem;
     color: var(--text-muted);
-    font-size: 0.82rem;
+    font-size: 0.83rem;
+    line-height: 1.65;
+}
+
+/* ── Skills ──────────────────────────────── */
+
+.skill-entry {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    padding: 0.75rem 0;
+    border-bottom: 1px solid var(--border);
+}
+
+.skill-entry:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.skill-entry h3 {
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    line-height: 1.4;
+}
+
+.skill-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+}
+
+.skill-chip {
+    display: inline-block;
+    padding: 0.18rem 0.55rem;
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    color: var(--text);
+    letter-spacing: 0.01em;
     line-height: 1.6;
+    background: transparent;
+    transition: border-color 0.12s, color 0.12s, background 0.12s;
+    white-space: nowrap;
+}
+
+.skill-chip:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+    background: oklch(54% 0.19 47 / 0.05);
+}
+
+[data-theme="dark"] .skill-chip:hover {
+    background: oklch(72% 0.17 52 / 0.08);
 }
 
 /* ── Contact ─────────────────────────────── */
@@ -294,8 +398,9 @@ html {
 .cv-contact-body {
     color: var(--text-muted);
     font-size: 0.875rem;
-    line-height: 1.7;
-    margin-bottom: 1.25rem;
+    line-height: 1.75;
+    margin-bottom: 1.35rem;
+    max-width: 56ch;
 }
 
 .cv-cta {
@@ -309,35 +414,43 @@ html {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-height: 2.25rem;
-    padding: 0.55rem 1.1rem;
+    min-height: 2.5rem;
+    padding: 0.6rem 1.4rem;
     border-radius: 4px;
-    background: var(--text);
-    color: var(--bg) !important;
+    background: var(--accent);
+    color: oklch(98% 0.005 80) !important;
     font-family: var(--font-sans) !important;
-    font-size: 0.825rem;
+    font-size: 0.8rem;
     font-weight: 600;
     text-decoration: none;
-    letter-spacing: 0.02em;
-    transition: opacity 0.12s;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    transition: opacity 0.15s, transform 0.15s;
 }
 
 .btn-primary:hover {
-    opacity: 0.78;
+    opacity: 0.88;
+    transform: translateY(-1px);
+}
+
+.btn-primary:active {
+    transform: translateY(0);
+    opacity: 1;
 }
 
 .btn-ghost {
     color: var(--text-muted);
     font-family: var(--font-mono);
-    font-size: 0.75rem;
+    font-size: 0.72rem;
     text-decoration: none;
     border-bottom: 1px solid var(--border);
     padding-bottom: 1px;
-    transition: color 0.12s;
+    transition: color 0.12s, border-color 0.12s;
 }
 
 .btn-ghost:hover {
     color: var(--accent);
+    border-color: var(--accent);
     opacity: 1;
 }
 
@@ -345,13 +458,13 @@ html {
 
 @media (max-width: 760px) {
     .cv-page-main {
-        padding: 1.5rem 1rem 4rem;
+        padding: 1.5rem 0.75rem 4rem;
     }
 
     .cv-header {
-        flex-direction: column;
-        gap: 1.25rem;
-        padding: 1.75rem 1.5rem;
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+        padding: 2rem 1.75rem 1.75rem;
     }
 
     .cv-header__contact {
@@ -359,7 +472,44 @@ html {
     }
 
     .cv-body {
-        padding: 1.75rem 1.5rem;
+        grid-template-columns: 1fr;
+    }
+
+    .cv-sidebar {
+        padding: 2rem 1.75rem;
+        border-right: none;
+        border-bottom: 1px solid var(--border);
+    }
+
+    [data-theme="dark"] .cv-sidebar {
+        border-bottom-color: oklch(28% 0.01 58);
+    }
+
+    .cv-main {
+        padding: 2rem 1.75rem;
+    }
+
+    .skill-chips {
+        gap: 0.25rem;
+    }
+}
+
+/* ── Mobile sidebar: chips can breathe wider ─ */
+
+@media (max-width: 760px) and (min-width: 481px) {
+    .skill-entry {
+        flex-direction: row;
+        align-items: flex-start;
+        gap: 0;
+    }
+
+    .skill-entry h3 {
+        flex: 0 0 120px;
+        padding-top: 0.22rem;
+    }
+
+    .skill-chips {
+        flex: 1;
     }
 }
 
@@ -367,8 +517,12 @@ html {
 
 @media (max-width: 480px) {
     .cv-page-main {
-        padding: 0.75rem 0 3rem;
+        padding: 0.5rem 0 3rem;
         background: var(--bg);
+    }
+
+    [data-theme="dark"] .cv-page-main {
+        background: oklch(9% 0.01 55);
     }
 
     .cv-card {
@@ -377,16 +531,26 @@ html {
     }
 
     .cv-header {
-        padding: 1.25rem 1.1rem;
+        padding: 1.5rem 1.25rem 1.35rem;
     }
 
-    .cv-body {
-        padding: 1.25rem 1.1rem;
+    .cv-sidebar {
+        padding: 1.5rem 1.25rem;
     }
 
-    .exp-item__header {
+    .cv-main {
+        padding: 1.5rem 1.25rem;
+    }
+
+    .exp-item__card-header {
         flex-direction: column;
-        gap: 0.2rem;
+        gap: 0.5rem;
+    }
+
+    .exp-item__meta {
+        align-items: flex-start;
+        flex-direction: row;
+        gap: 0.75rem;
     }
 
     .btn-primary {

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -47,6 +47,17 @@
     border-bottom-color: oklch(30% 0.01 58);
 }
 
+.cv-header__identity {
+    min-width: 0;
+}
+
+.cv-header__meta-row {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+}
+
 .cv-name {
     font-family: var(--font-serif);
     font-size: clamp(3rem, 7vw, 5.5rem);

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -149,6 +149,10 @@
     opacity: 0.6;
 }
 
+.cv-imdb-link svg {
+    flex-shrink: 0;
+}
+
 /* ── Scroll offset for fixed nav ─────────── */
 
 [id] {

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -475,6 +475,10 @@
         grid-template-columns: 1fr;
     }
 
+    .cv-main {
+        order: -1;
+    }
+
     .cv-sidebar {
         padding: 2rem 1.75rem;
         border-right: none;

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,7 +32,7 @@
             } catch (err) {}
         })();
     </script>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600&family=Barlow+Condensed:wght@600;700;800&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css', v=config.asset_version) }}">
     {% if config.plausible_script_url %}
         <script

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,7 +32,7 @@
             } catch (err) {}
         })();
     </script>
-    <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600&family=Barlow+Condensed:wght@600;700;800&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600&family=Barlow+Condensed:wght@600;700;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css', v=config.asset_version) }}">
     {% if config.plausible_script_url %}
         <script

--- a/templates/base.html
+++ b/templates/base.html
@@ -48,7 +48,7 @@
     <nav class="navbar" aria-label="Primary">
         <div class="nav-content">
             <div class="nav-brand">
-                <a href="{{ site_links.home }}" class="nav-name-link">{{ config.name }}</a>
+                <a href="{{ site_links.home }}" class="nav-name-link" aria-label="{{ config.name }}">SG</a>
             </div>
             <div class="nav-links" id="nav-links">
                 {% for item in nav_links %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,7 +13,7 @@
     
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600&family=Barlow+Condensed:wght@600;700;800&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css', v=config.asset_version) }}">
 </head>
 <body>

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -41,7 +41,14 @@
             </a>
             {% endif %}
             {% if config.imdb_url %}
-            <a href="{{ config.imdb_url }}" target="_blank" rel="noopener noreferrer">IMDb<span class="sr-only"> (opens in new tab)</span></a>
+            <a href="{{ config.imdb_url }}" target="_blank" rel="noopener noreferrer" class="cv-social-link cv-imdb-link">
+                <svg width="30" height="14" viewBox="0 0 30 14" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                    <rect width="30" height="14" rx="2" fill="currentColor" fill-opacity="0.09"/>
+                    <rect x="0.5" y="0.5" width="29" height="13" rx="2" stroke="currentColor" stroke-opacity="0.32"/>
+                    <text x="4" y="10.5" font-family="var(--font-mono), monospace" font-weight="700" font-size="7.5" fill="currentColor" letter-spacing="0.04em">IMDb</text>
+                </svg>
+                <span class="sr-only">IMDb profile (opens in new tab)</span>
+            </a>
             {% endif %}
             <span class="cv-location">{{ config.location }}</span>
         </div>

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -45,7 +45,7 @@
                 <svg width="30" height="14" viewBox="0 0 30 14" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                     <rect width="30" height="14" rx="2" fill="currentColor" fill-opacity="0.09"/>
                     <rect x="0.5" y="0.5" width="29" height="13" rx="2" stroke="currentColor" stroke-opacity="0.32"/>
-                    <text x="4" y="10.5" font-family="var(--font-mono), monospace" font-weight="700" font-size="7.5" fill="currentColor" letter-spacing="0.04em">IMDb</text>
+                    <text x="4" y="10.5" font-family="'JetBrains Mono', monospace" font-weight="700" font-size="7.5" fill="currentColor" letter-spacing="0.04em">IMDb</text>
                 </svg>
                 <span class="sr-only">IMDb profile (opens in new tab)</span>
             </a>
@@ -91,7 +91,7 @@
         </aside>
 
         <!-- Right main: experience -->
-        <main class="cv-main">
+        <div class="cv-main">
 
             <section id="experience" class="cv-section" aria-labelledby="exp-label">
                 <h2 id="exp-label" class="cv-label">Experience</h2>
@@ -114,7 +114,7 @@
                 {% endfor %}
             </section>
 
-        </main>
+        </div>
 
     </div><!-- /.cv-body -->
 

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -11,15 +11,17 @@
 <div class="cv-wrap">
 <div class="cv-card">
 
-    <!-- ── Header: name + contact ── -->
+    <!-- ── Header: display name + contact ── -->
     <header class="cv-header">
         <div class="cv-header__identity">
             <h1 class="cv-name">{{ config.name }}</h1>
-            <p class="cv-subtitle">{{ config.tagline }}</p>
-            <span class="cv-availability">
-                <span class="cv-availability__dot" aria-hidden="true"></span>
-                Available for work
-            </span>
+            <div class="cv-header__meta-row">
+                <p class="cv-subtitle">{{ config.tagline }}</p>
+                <span class="cv-availability">
+                    <span class="cv-availability__dot" aria-hidden="true"></span>
+                    Available for work
+                </span>
+            </div>
         </div>
         <div class="cv-header__contact" aria-label="Contact details">
             <a href="mailto:{{ config.email }}">{{ config.email }}</a>
@@ -28,13 +30,13 @@
             {% endif %}
             {% if config.linkedin_url %}
             <a href="{{ config.linkedin_url }}" target="_blank" rel="noopener noreferrer" class="cv-social-link">
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
                 LinkedIn<span class="sr-only"> (opens in new tab)</span>
             </a>
             {% endif %}
             {% if config.github_url %}
             <a href="{{ config.github_url }}" target="_blank" rel="noopener noreferrer" class="cv-social-link">
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
                 GitHub<span class="sr-only"> (opens in new tab)</span>
             </a>
             {% endif %}
@@ -45,30 +47,15 @@
         </div>
     </header>
 
-    <!-- ── Body ── -->
+    <!-- ── Body: sidebar + main ── -->
     <div class="cv-body">
 
-        <div class="cv-col">
+        <!-- Left sidebar: profile, skills, contact -->
+        <aside class="cv-sidebar">
 
             <section id="profile" class="cv-section" aria-labelledby="profile-label">
                 <h2 id="profile-label" class="cv-label">Profile</h2>
                 <p class="cv-profile-text">{{ cv.summary }}</p>
-            </section>
-
-            <section id="experience" class="cv-section" aria-labelledby="exp-label">
-                <h2 id="exp-label" class="cv-label">Experience</h2>
-                {% for item in cv.experience %}
-                <article class="exp-item">
-                    <div class="exp-item__header">
-                        <h3 class="exp-item__role">{{ item.role }}</h3>
-                        <span class="exp-item__period">{{ item.period }}</span>
-                    </div>
-                    <p class="exp-item__company">{{ item.company }} &middot; {{ item.location }}</p>
-                    <ul class="exp-item__list">
-                        {% for h in item.highlights %}<li>{{ h }}</li>{% endfor %}
-                    </ul>
-                </article>
-                {% endfor %}
             </section>
 
             <section id="skills" class="cv-section" aria-labelledby="skills-label">
@@ -76,7 +63,9 @@
                 {% for group in cv.skills %}
                 <div class="skill-entry">
                     <h3>{{ group.group }}</h3>
-                    <p>{{ group['items'] | join(', ') }}</p>
+                    <div class="skill-chips">
+                        {% for item in group['items'] %}<span class="skill-chip">{{ item }}</span>{% endfor %}
+                    </div>
                 </div>
                 {% endfor %}
             </section>
@@ -92,9 +81,36 @@
                 </div>
             </section>
 
-        </div>
-    </div>
+        </aside>
 
-</div>
-</div>
+        <!-- Right main: experience -->
+        <main class="cv-main">
+
+            <section id="experience" class="cv-section" aria-labelledby="exp-label">
+                <h2 id="exp-label" class="cv-label">Experience</h2>
+                {% for item in cv.experience %}
+                <article class="exp-item">
+                    <div class="exp-item__card-header">
+                        <div class="exp-item__identity">
+                            <h3 class="exp-item__company">{{ item.company }}</h3>
+                            <p class="exp-item__role">{{ item.role }}</p>
+                        </div>
+                        <div class="exp-item__meta">
+                            <span class="exp-item__period">{{ item.period }}</span>
+                            <span class="exp-item__location">{{ item.location }}</span>
+                        </div>
+                    </div>
+                    <ul class="exp-item__list">
+                        {% for h in item.highlights %}<li>{{ h }}</li>{% endfor %}
+                    </ul>
+                </article>
+                {% endfor %}
+            </section>
+
+        </main>
+
+    </div><!-- /.cv-body -->
+
+</div><!-- /.cv-card -->
+</div><!-- /.cv-wrap -->
 {% endblock %}


### PR DESCRIPTION
## Summary

- Restructures the landing page into a two-column CV layout (280px sidebar + fluid main)
- Adds IMDb profile link as a monochromatic inline SVG badge in the CV header, matching the weight and tone of LinkedIn/GitHub links
- Replaces full name in navbar with compact SG monogram
- Fixes mobile layout order so Experience appears before Profile/Skills
- Responsive collapse: two columns → stacked at tablet, full mobile treatment at ≤480px

## Test plan

- [x] Desktop: two-column layout renders correctly; sidebar and main column aligned
- [x] IMDb badge visible in header contact section, readable in light and dark mode
- [x] LinkedIn, GitHub, IMDb links all open in new tab
- [x] Tablet (760px): columns stack, skills section switches to row layout
- [x] Mobile (480px): Experience section appears before Profile/Skills
- [x] Navbar shows "SG" monogram, not full name
- [x] Dark mode: all sections, badges, and borders use correct theme tokens

Closes #222