### PR TITLE
feat(design): replace Barlow with DM Sans + JetBrains Mono font system

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -11,9 +11,9 @@
     --nav-bg: oklch(98.5% 0.006 80 / 0.95);
     --wrap-width: 700px;
     --nav-height: 56px;
-    --font-sans: 'Barlow', system-ui, -apple-system, sans-serif;
-    --font-serif: 'Barlow Condensed', system-ui, sans-serif;
-    --font-body: 'Barlow', system-ui, -apple-system, sans-serif;
+    --font-sans: 'DM Sans', system-ui, -apple-system, sans-serif;
+    --font-display: 'DM Sans', system-ui, sans-serif;
+    --font-body: 'DM Sans', system-ui, -apple-system, sans-serif;
     --font-mono: 'JetBrains Mono', 'SFMono-Regular', Menlo, monospace;
 }
 
@@ -110,10 +110,10 @@ a:focus-visible {
 p { max-width: 68ch; line-height: 1.8; }
 
 h1, h2, h3, h4 {
-    font-family: var(--font-serif);
+    font-family: var(--font-display);
     font-weight: 700;
     line-height: 1.1;
-    letter-spacing: -0.01em;
+    letter-spacing: -0.02em;
     overflow-wrap: break-word;
 }
 

--- a/static/css/components-blog.css
+++ b/static/css/components-blog.css
@@ -9,7 +9,7 @@
 }
 
 .blog-list-header h1 {
-    font-family: var(--font-serif);
+    font-family: var(--font-display);
     font-size: clamp(2rem, 5vw, 2.75rem);
     font-weight: 600;
     letter-spacing: -0.03em;
@@ -79,7 +79,7 @@
 
 .post-list .post-title {
     display: block;
-    font-family: var(--font-serif);
+    font-family: var(--font-display);
     font-size: 1.1rem;
     font-weight: 600;
     line-height: 1.4;
@@ -344,7 +344,7 @@
 .blog-related a:hover::before { opacity: 1; }
 
 .related-title {
-    font-family: var(--font-serif);
+    font-family: var(--font-display);
     font-size: 0.975rem;
     font-weight: 600;
     letter-spacing: -0.01em;

--- a/static/css/components-core.css
+++ b/static/css/components-core.css
@@ -1291,7 +1291,7 @@ section h2 {
 .home-intro { padding-top: 3rem; }
 
 .home-intro h1 {
-    font-family: var(--font-serif);
+    font-family: var(--font-display);
     font-size: clamp(2.75rem, 6vw, 4rem);
     font-weight: 800;
     letter-spacing: -0.02em;
@@ -1348,7 +1348,7 @@ section h2 {
 }
 
 .about-header h1 {
-    font-family: var(--font-serif);
+    font-family: var(--font-display);
     font-size: clamp(3.5rem, 9vw, 5.5rem);
     font-weight: 800;
     letter-spacing: -0.02em;
@@ -1371,7 +1371,7 @@ section h2 {
 
 .about-body h2,
 .about-links h2 {
-    font-family: var(--font-serif);
+    font-family: var(--font-display);
     font-size: clamp(1.3rem, 3vw, 1.6rem);
     font-weight: 700;
     letter-spacing: -0.01em;

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -59,12 +59,11 @@
 }
 
 .cv-name {
-    font-family: var(--font-serif);
-    font-size: clamp(3rem, 7vw, 5.5rem);
-    font-weight: 800;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    line-height: 0.95;
+    font-family: var(--font-display);
+    font-size: clamp(2.5rem, 6vw, 4.25rem);
+    font-weight: 900;
+    letter-spacing: -0.03em;
+    line-height: 1.05;
     color: var(--text);
 }
 
@@ -208,10 +207,10 @@
     gap: 0.6rem;
     margin-bottom: 1.1rem;
     color: var(--accent);
-    font-family: var(--font-serif);
-    font-size: 0.6rem;
-    font-weight: 700;
-    letter-spacing: 0.18em;
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    font-weight: 600;
+    letter-spacing: 0.14em;
     text-transform: uppercase;
     line-height: 1.4;
 }
@@ -288,13 +287,12 @@
 }
 
 .exp-item__company {
-    font-family: var(--font-serif);
-    font-size: 1.05rem;
+    font-family: var(--font-display);
+    font-size: 1.1rem;
     font-weight: 800;
     color: var(--text);
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-    line-height: 1.15;
+    letter-spacing: -0.015em;
+    line-height: 1.2;
 }
 
 .exp-item__role {

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,7 +32,7 @@
             } catch (err) {}
         })();
     </script>
-    <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600&family=Barlow+Condensed:wght@600;700;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400..1000&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css', v=config.asset_version) }}">
     {% if config.plausible_script_url %}
         <script

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,7 +13,7 @@
     
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600&family=Barlow+Condensed:wght@600;700;800&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400..1000&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css', v=config.asset_version) }}">
 </head>
 <body>


### PR DESCRIPTION
## Summary
Implements the font-system swap from #253, with one deliberate pivot: **DM Sans instead of Bricolage Grotesque**. The Bricolage / "Signal Brief" direction from DESIGN.md was reviewed and rejected in favor of the warmer, more personal DM Sans direction.

## Changes
- Google Fonts load in `base.html` (and orphaned `index.html`): DM Sans variable font (opsz 9-40, wght 400-1000) + JetBrains Mono 400/500/600
- `base.css`: `--font-sans` / `--font-body` now DM Sans; `--font-serif` renamed to `--font-display` (it was never a serif)
- All nine `var(--font-serif)` usages across `landing.css`, `components-core.css`, `components-blog.css` updated to `var(--font-display)`
- CV typography retuned for a non-condensed face: name and company headings drop uppercase + wide tracking in favor of weight 800-900 with negative tracking; section labels move to JetBrains Mono per the labels/metadata rule

## Acceptance criteria from #253
- [x] Display font renders for all headings and display type (DM Sans, not Bricolage; see pivot note)
- [x] Body text renders in the body family
- [x] JetBrains Mono for labels, metadata, dates only
- [x] No Barlow references remain in CSS or templates
- [x] Light and dark mode both use token-driven families
- [x] flake8 clean, 23/23 tests pass

Closes #253