### PR TITLE
feat(design): neutral monochrome palette with single emerald accent

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -3,12 +3,12 @@
 
 /* Variables */
 :root {
-    --bg: oklch(98.5% 0.006 80);
-    --text: oklch(16% 0.012 60);
-    --text-muted: oklch(52% 0.01 65);
-    --accent: oklch(54% 0.19 47);
-    --border: oklch(89% 0.008 75);
-    --nav-bg: oklch(98.5% 0.006 80 / 0.95);
+    --bg: oklch(98.5% 0 0);
+    --text: oklch(18% 0 0);
+    --text-muted: oklch(46% 0 0);
+    --accent: oklch(52% 0.125 165);
+    --border: oklch(90% 0 0);
+    --nav-bg: oklch(98.5% 0 0 / 0.95);
     --wrap-width: 700px;
     --nav-height: 56px;
     --font-sans: 'DM Sans', system-ui, -apple-system, sans-serif;
@@ -18,12 +18,12 @@
 }
 
 html[data-theme="dark"] {
-    --bg: oklch(13% 0.008 60);
-    --text: oklch(84% 0.012 70);
-    --text-muted: oklch(58% 0.012 65);
-    --accent: oklch(72% 0.17 52);
-    --border: oklch(28% 0.01 60 / 0.7);
-    --nav-bg: oklch(13% 0.008 60 / 0.95);
+    --bg: oklch(14% 0 0);
+    --text: oklch(86% 0 0);
+    --text-muted: oklch(62% 0 0);
+    --accent: oklch(73% 0.13 162);
+    --border: oklch(28% 0 0 / 0.7);
+    --nav-bg: oklch(14% 0 0 / 0.95);
 }
 
 html { scroll-behavior: smooth; }
@@ -90,7 +90,7 @@ body {
     -webkit-font-smoothing: antialiased;
 }
 
-::selection { background: var(--accent); color: #fff; }
+::selection { background: var(--accent); color: oklch(98.5% 0 0); }
 
 a {
     color: var(--accent);

--- a/static/css/components-core.css
+++ b/static/css/components-core.css
@@ -90,12 +90,12 @@
     background: var(--accent);
     color: #fff;
     border: none;
-    box-shadow: 0 6px 20px oklch(54% 0.19 47 / 0.3);
+    box-shadow: 0 6px 20px color-mix(in oklch, var(--accent) 30%, transparent);
 }
 
 .primary-cta:hover {
     transform: translateY(-2px);
-    box-shadow: 0 10px 28px oklch(54% 0.19 47 / 0.4);
+    box-shadow: 0 10px 28px color-mix(in oklch, var(--accent) 40%, transparent);
 }
 
 /* Secondary CTA Button - Outline style */
@@ -710,7 +710,7 @@ section h2 {
 
 .submit-button:hover {
     transform: translateY(-2px);
-    box-shadow: 0 8px 24px oklch(54% 0.19 47 / 0.3);
+    box-shadow: 0 8px 24px color-mix(in oklch, var(--accent) 30%, transparent);
 }
 
 .submit-button:active {

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -4,11 +4,11 @@
 
 .cv-page-main {
     padding: 3rem 1.5rem 6rem;
-    background: oklch(88% 0.01 75);
+    background: oklch(93% 0 0);
 }
 
 [data-theme="dark"] .cv-page-main {
-    background: oklch(9% 0.01 55);
+    background: oklch(8% 0 0);
 }
 
 /* ── Card wrapper ────────────────────────── */
@@ -26,7 +26,7 @@
 }
 
 [data-theme="dark"] .cv-card {
-    background: oklch(16% 0.009 58);
+    background: oklch(16.5% 0 0);
     box-shadow: 0 4px 48px oklch(0% 0 0 / 0.6);
 }
 
@@ -43,8 +43,8 @@
 }
 
 [data-theme="dark"] .cv-header {
-    background: oklch(14% 0.01 58);
-    border-bottom-color: oklch(30% 0.01 58);
+    background: oklch(15% 0 0);
+    border-bottom-color: oklch(30% 0 0);
 }
 
 .cv-header__identity {
@@ -115,32 +115,22 @@
     margin-top: 1rem;
     padding: 0.32rem 0.85rem 0.32rem 0.65rem;
     border-radius: 999px;
-    border: 1px solid oklch(52% 0.18 145 / 0.3);
-    background: oklch(52% 0.18 145 / 0.06);
-    color: oklch(40% 0.18 145);
+    border: 1px solid color-mix(in oklch, var(--accent) 30%, transparent);
+    background: color-mix(in oklch, var(--accent) 6%, transparent);
+    color: var(--accent);
     font-family: var(--font-sans);
     font-size: 0.7rem;
     font-weight: 600;
     letter-spacing: 0.04em;
 }
 
-[data-theme="dark"] .cv-availability {
-    color: oklch(70% 0.18 145);
-    background: oklch(52% 0.18 145 / 0.1);
-    border-color: oklch(52% 0.18 145 / 0.28);
-}
-
 .cv-availability__dot {
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    background: oklch(50% 0.18 145);
+    background: var(--accent);
     flex-shrink: 0;
     animation: pulse-dot 2.5s ease-in-out infinite;
-}
-
-[data-theme="dark"] .cv-availability__dot {
-    background: oklch(68% 0.18 145);
 }
 
 @keyframes pulse-dot {
@@ -181,8 +171,8 @@
 }
 
 [data-theme="dark"] .cv-sidebar {
-    background: oklch(14.5% 0.009 58);
-    border-right-color: oklch(28% 0.01 58);
+    background: oklch(15% 0 0);
+    border-right-color: oklch(28% 0 0);
 }
 
 .cv-main {
@@ -250,7 +240,7 @@
 }
 
 [data-theme="dark"] .exp-item {
-    background: oklch(18% 0.009 58);
+    background: oklch(18% 0 0);
 }
 
 .exp-item:last-child {
@@ -273,13 +263,13 @@
     align-items: flex-start;
     gap: 1rem;
     padding: 1rem 1.35rem 0.85rem;
-    background: oklch(97% 0.004 75);
+    background: oklch(97% 0 0);
     border-bottom: 1px solid var(--border);
 }
 
 [data-theme="dark"] .exp-item__card-header {
-    background: oklch(21% 0.01 58);
-    border-bottom-color: oklch(28% 0.01 58);
+    background: oklch(21% 0 0);
+    border-bottom-color: oklch(28% 0 0);
 }
 
 .exp-item__identity {
@@ -390,11 +380,11 @@
 .skill-chip:hover {
     border-color: var(--accent);
     color: var(--accent);
-    background: oklch(54% 0.19 47 / 0.05);
+    background: color-mix(in oklch, var(--accent) 6%, transparent);
 }
 
 [data-theme="dark"] .skill-chip:hover {
-    background: oklch(72% 0.17 52 / 0.08);
+    background: color-mix(in oklch, var(--accent) 10%, transparent);
 }
 
 /* ── Contact ─────────────────────────────── */
@@ -428,7 +418,7 @@
     padding: 0.6rem 1.4rem;
     border-radius: 4px;
     background: var(--accent);
-    color: oklch(98% 0.005 80) !important;
+    color: oklch(98.5% 0 0) !important;
     font-family: var(--font-sans) !important;
     font-size: 0.8rem;
     font-weight: 600;
@@ -496,7 +486,7 @@
     }
 
     [data-theme="dark"] .cv-sidebar {
-        border-bottom-color: oklch(28% 0.01 58);
+        border-bottom-color: oklch(28% 0 0);
     }
 
     .cv-main {
@@ -536,7 +526,7 @@
     }
 
     [data-theme="dark"] .cv-page-main {
-        background: oklch(9% 0.01 55);
+        background: oklch(8% 0 0);
     }
 
     .cv-card {


### PR DESCRIPTION
## Summary
Implements #260: replaces the warm beige/orange palette with true-neutral monochrome plus one emerald accent.

**Stacked on #258** (font system) so the diff stays clean. Merge #258 first; GitHub will retarget this PR to `dev` automatically.

## Changes
- `base.css` tokens: zero-chroma neutrals in both themes; accent is emerald (light `oklch(52% 0.125 165)` ~5.5:1 on the light bg, dark `oklch(73% 0.13 162)`)
- Availability badge now derives from the accent via `color-mix` instead of its own green, fixing the competing-accent problem; its dark-mode override blocks are gone
- All hardcoded warm oklch surfaces in `landing.css` and the orange-tinted button shadows in `components-core.css` are now neutral or accent-derived
- `::selection` text uses off-white instead of pure `#fff`

## Acceptance criteria from #260
- [x] Neutral bg/text/muted/border tokens, both themes
- [x] No hardcoded warm-hue oklch values left in component CSS
- [x] Single accent across the page, availability dot included
- [x] Accent passes WCAG AA in both themes
- [x] flake8 clean, 23/23 tests pass

Closes #260