### PR TITLE
feat(cv): surface studio credits, shipped titles, and education

### DIFF
--- a/app.py
+++ b/app.py
@@ -246,24 +246,30 @@ CV_PAGE = {
         'Boulder Media',
         'GameCityKajaani',
     ],
+    'core_skills': [
+        'Python',
+        'Linux',
+        'Maya',
+        'Katana',
+        'USD / Alembic',
+        'RenderMan',
+    ],
     'skills': [
         {
             'group': 'Languages and systems',
-            'items': ['Python', 'Linux', 'Lua', 'Git', 'Sprint development'],
+            'items': ['Lua', 'Git', 'Sprint development'],
         },
         {
             'group': 'DCC and pipeline',
             'items': [
-                'Maya',
                 'Houdini',
-                'Katana',
                 'Nuke',
                 'ShotGrid / Flow',
             ],
         },
         {
             'group': 'Rendering and data',
-            'items': ['USD / Alembic', 'RenderMan', 'Deadline', 'V-Ray', 'Redshift'],
+            'items': ['Deadline', 'V-Ray', 'Redshift'],
         },
         {
             'group': 'Production practice',

--- a/app.py
+++ b/app.py
@@ -246,6 +246,12 @@ CV_PAGE = {
         'Boulder Media',
         'GameCityKajaani',
     ],
+    'studio_strip': ['Disney', 'Blizzard', 'DNEG', 'Boulder Media'],
+    'selected_credits': [
+        {'title': 'Overwatch 2', 'studio': 'Blizzard Entertainment'},
+        {'title': 'My Little Pony: A New Generation', 'studio': 'Boulder Media'},
+        {'title': 'Garfield', 'studio': 'DNEG'},
+    ],
     'core_skills': [
         'Python',
         'Linux',

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -3,12 +3,12 @@
 
 /* Variables */
 :root {
-    --bg: oklch(98.5% 0.006 80);
-    --text: oklch(16% 0.012 60);
-    --text-muted: oklch(52% 0.01 65);
-    --accent: oklch(54% 0.19 47);
-    --border: oklch(89% 0.008 75);
-    --nav-bg: oklch(98.5% 0.006 80 / 0.95);
+    --bg: oklch(98.5% 0 0);
+    --text: oklch(18% 0 0);
+    --text-muted: oklch(46% 0 0);
+    --accent: oklch(52% 0.125 165);
+    --border: oklch(90% 0 0);
+    --nav-bg: oklch(98.5% 0 0 / 0.95);
     --wrap-width: 700px;
     --nav-height: 56px;
     --font-sans: 'DM Sans', system-ui, -apple-system, sans-serif;
@@ -18,12 +18,12 @@
 }
 
 html[data-theme="dark"] {
-    --bg: oklch(13% 0.008 60);
-    --text: oklch(84% 0.012 70);
-    --text-muted: oklch(58% 0.012 65);
-    --accent: oklch(72% 0.17 52);
-    --border: oklch(28% 0.01 60 / 0.7);
-    --nav-bg: oklch(13% 0.008 60 / 0.95);
+    --bg: oklch(14% 0 0);
+    --text: oklch(86% 0 0);
+    --text-muted: oklch(62% 0 0);
+    --accent: oklch(73% 0.13 162);
+    --border: oklch(28% 0 0 / 0.7);
+    --nav-bg: oklch(14% 0 0 / 0.95);
 }
 
 html { scroll-behavior: smooth; }
@@ -90,7 +90,7 @@ body {
     -webkit-font-smoothing: antialiased;
 }
 
-::selection { background: var(--accent); color: #fff; }
+::selection { background: var(--accent); color: oklch(98.5% 0 0); }
 
 a {
     color: var(--accent);

--- a/static/css/components-core.css
+++ b/static/css/components-core.css
@@ -90,12 +90,12 @@
     background: var(--accent);
     color: #fff;
     border: none;
-    box-shadow: 0 6px 20px oklch(54% 0.19 47 / 0.3);
+    box-shadow: 0 6px 20px color-mix(in oklch, var(--accent) 30%, transparent);
 }
 
 .primary-cta:hover {
     transform: translateY(-2px);
-    box-shadow: 0 10px 28px oklch(54% 0.19 47 / 0.4);
+    box-shadow: 0 10px 28px color-mix(in oklch, var(--accent) 40%, transparent);
 }
 
 /* Secondary CTA Button - Outline style */
@@ -710,7 +710,7 @@ section h2 {
 
 .submit-button:hover {
     transform: translateY(-2px);
-    box-shadow: 0 8px 24px oklch(54% 0.19 47 / 0.3);
+    box-shadow: 0 8px 24px color-mix(in oklch, var(--accent) 30%, transparent);
 }
 
 .submit-button:active {

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -233,10 +233,57 @@
 
 /* ── Skills band ─────────────────────────── */
 
+.skills-core {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 2rem;
+}
+
+.skill-chip--core {
+    padding: 0.45rem 0.95rem;
+    border-radius: 5px;
+    border-color: color-mix(in oklch, var(--accent) 35%, transparent);
+    background: color-mix(in oklch, var(--accent) 7%, transparent);
+    font-size: 0.82rem;
+    font-weight: 500;
+    color: var(--text);
+}
+
 .skills-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
     gap: 1.75rem 2.5rem;
+}
+
+/* ── Skills reveal: staggered entrance ───── */
+/* Chips hide only once JS confirms it can reveal them
+   (js-reveal-ready), so content is never lost without JS. */
+
+@media (prefers-reduced-motion: no-preference) {
+    #skills.js-reveal-ready:not(.is-revealed) .skill-chip {
+        opacity: 0;
+    }
+
+    #skills.is-revealed .skill-chip {
+        animation: chip-in 0.5s cubic-bezier(0.16, 1, 0.3, 1) backwards;
+        animation-delay: calc(var(--i, 0) * 45ms);
+    }
+
+    #skills.is-revealed .skills-grid .skill-chip {
+        animation-delay: calc(240ms + var(--g, 0) * 120ms + var(--i, 0) * 35ms);
+    }
+}
+
+@keyframes chip-in {
+    from {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+    to {
+        opacity: 1;
+        transform: none;
+    }
 }
 
 .skill-entry {
@@ -272,7 +319,8 @@
     letter-spacing: 0.01em;
     line-height: 1.6;
     background: transparent;
-    transition: border-color 0.12s, color 0.12s, background 0.12s;
+    transition: border-color 0.12s, color 0.12s, background 0.12s,
+        transform 0.15s ease;
     white-space: nowrap;
 }
 
@@ -280,6 +328,7 @@
     border-color: var(--accent);
     color: var(--accent);
     background: color-mix(in oklch, var(--accent) 6%, transparent);
+    transform: translateY(-1px);
 }
 
 /* ── Contact ─────────────────────────────── */

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -61,6 +61,22 @@
     max-width: 58ch;
 }
 
+.cv-studios {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem 1.5rem;
+    margin-top: 1.5rem;
+}
+
+.cv-studios span {
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+
 .cv-hero__status {
     display: flex;
     align-items: center;
@@ -229,6 +245,82 @@
     color: var(--text-muted);
     font-size: 0.9rem;
     line-height: 1.7;
+}
+
+/* ── Selected credits ────────────────────── */
+
+.credit-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.5rem 2.5rem;
+}
+
+.credit-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.credit-item__title {
+    font-family: var(--font-display);
+    font-size: 1.05rem;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    line-height: 1.3;
+    color: var(--text);
+}
+
+.credit-item__studio {
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+/* ── Education ───────────────────────────── */
+
+.edu-item {
+    display: grid;
+    grid-template-columns: 150px 1fr;
+    gap: 0.5rem 2.5rem;
+    padding: 0.85rem 0;
+}
+
+.edu-item + .edu-item {
+    border-top: 1px solid var(--border);
+}
+
+.edu-item__period {
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    white-space: nowrap;
+    padding-top: 0.2rem;
+}
+
+.edu-item__body {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.35rem 1rem;
+    max-width: none;
+}
+
+.edu-item__school {
+    font-weight: 700;
+    font-size: 0.95rem;
+    color: var(--text);
+}
+
+.edu-item__credential {
+    color: var(--text-muted);
+    font-size: 0.875rem;
 }
 
 /* ── Skills band ─────────────────────────── */
@@ -473,6 +565,17 @@
         align-items: center;
         gap: 0.75rem;
         padding-top: 0;
+    }
+
+    .credit-list {
+        grid-template-columns: 1fr;
+        gap: 1.25rem;
+    }
+
+    .edu-item {
+        grid-template-columns: 1fr;
+        gap: 0.25rem;
+        padding: 0.75rem 0;
     }
 }
 

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -4,11 +4,11 @@
 
 .cv-page-main {
     padding: 3rem 1.5rem 6rem;
-    background: oklch(88% 0.01 75);
+    background: oklch(93% 0 0);
 }
 
 [data-theme="dark"] .cv-page-main {
-    background: oklch(9% 0.01 55);
+    background: oklch(8% 0 0);
 }
 
 /* ── Card wrapper ────────────────────────── */
@@ -26,7 +26,7 @@
 }
 
 [data-theme="dark"] .cv-card {
-    background: oklch(16% 0.009 58);
+    background: oklch(16.5% 0 0);
     box-shadow: 0 4px 48px oklch(0% 0 0 / 0.6);
 }
 
@@ -43,8 +43,8 @@
 }
 
 [data-theme="dark"] .cv-header {
-    background: oklch(14% 0.01 58);
-    border-bottom-color: oklch(30% 0.01 58);
+    background: oklch(15% 0 0);
+    border-bottom-color: oklch(30% 0 0);
 }
 
 .cv-header__identity {
@@ -115,32 +115,22 @@
     margin-top: 1rem;
     padding: 0.32rem 0.85rem 0.32rem 0.65rem;
     border-radius: 999px;
-    border: 1px solid oklch(52% 0.18 145 / 0.3);
-    background: oklch(52% 0.18 145 / 0.06);
-    color: oklch(40% 0.18 145);
+    border: 1px solid color-mix(in oklch, var(--accent) 30%, transparent);
+    background: color-mix(in oklch, var(--accent) 6%, transparent);
+    color: var(--accent);
     font-family: var(--font-sans);
     font-size: 0.7rem;
     font-weight: 600;
     letter-spacing: 0.04em;
 }
 
-[data-theme="dark"] .cv-availability {
-    color: oklch(70% 0.18 145);
-    background: oklch(52% 0.18 145 / 0.1);
-    border-color: oklch(52% 0.18 145 / 0.28);
-}
-
 .cv-availability__dot {
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    background: oklch(50% 0.18 145);
+    background: var(--accent);
     flex-shrink: 0;
     animation: pulse-dot 2.5s ease-in-out infinite;
-}
-
-[data-theme="dark"] .cv-availability__dot {
-    background: oklch(68% 0.18 145);
 }
 
 @keyframes pulse-dot {
@@ -181,8 +171,8 @@
 }
 
 [data-theme="dark"] .cv-sidebar {
-    background: oklch(14.5% 0.009 58);
-    border-right-color: oklch(28% 0.01 58);
+    background: oklch(15% 0 0);
+    border-right-color: oklch(28% 0 0);
 }
 
 .cv-main {
@@ -250,7 +240,7 @@
 }
 
 [data-theme="dark"] .exp-item {
-    background: oklch(18% 0.009 58);
+    background: oklch(18% 0 0);
 }
 
 .exp-item:last-child {
@@ -273,13 +263,13 @@
     align-items: flex-start;
     gap: 1rem;
     padding: 1rem 1.35rem 0.85rem;
-    background: oklch(97% 0.004 75);
+    background: oklch(97% 0 0);
     border-bottom: 1px solid var(--border);
 }
 
 [data-theme="dark"] .exp-item__card-header {
-    background: oklch(21% 0.01 58);
-    border-bottom-color: oklch(28% 0.01 58);
+    background: oklch(21% 0 0);
+    border-bottom-color: oklch(28% 0 0);
 }
 
 .exp-item__identity {
@@ -390,11 +380,11 @@
 .skill-chip:hover {
     border-color: var(--accent);
     color: var(--accent);
-    background: oklch(54% 0.19 47 / 0.05);
+    background: color-mix(in oklch, var(--accent) 6%, transparent);
 }
 
 [data-theme="dark"] .skill-chip:hover {
-    background: oklch(72% 0.17 52 / 0.08);
+    background: color-mix(in oklch, var(--accent) 10%, transparent);
 }
 
 /* ── Contact ─────────────────────────────── */
@@ -428,7 +418,7 @@
     padding: 0.6rem 1.4rem;
     border-radius: 4px;
     background: var(--accent);
-    color: oklch(98% 0.005 80) !important;
+    color: oklch(98.5% 0 0) !important;
     font-family: var(--font-sans) !important;
     font-size: 0.8rem;
     font-weight: 600;
@@ -496,7 +486,7 @@
     }
 
     [data-theme="dark"] .cv-sidebar {
-        border-bottom-color: oklch(28% 0.01 58);
+        border-bottom-color: oklch(28% 0 0);
     }
 
     .cv-main {
@@ -536,7 +526,7 @@
     }
 
     [data-theme="dark"] .cv-page-main {
-        background: oklch(9% 0.01 55);
+        background: oklch(8% 0 0);
     }
 
     .cv-card {

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -1,109 +1,108 @@
 @import url('base.css');
 
-/* ── Page background ─────────────────────── */
+/* ── Page ────────────────────────────────── */
 
 .cv-page-main {
-    padding: 3rem 1.5rem 6rem;
-    background: oklch(93% 0 0);
+    padding: 2.5rem 1.5rem 6rem;
+    background: var(--bg);
 }
 
-[data-theme="dark"] .cv-page-main {
-    background: oklch(8% 0 0);
-}
-
-/* ── Card wrapper ────────────────────────── */
-
-.cv-wrap {
-    max-width: 1040px;
+.cv-page {
+    max-width: 880px;
     margin: 0 auto;
 }
 
-.cv-card {
-    background: var(--bg);
-    border-radius: 6px;
-    box-shadow: 0 1px 3px oklch(0% 0 0 / 0.08), 0 8px 32px oklch(0% 0 0 / 0.1);
-    overflow: hidden;
+/* ── Scroll offset for fixed nav ─────────── */
+
+[id] {
+    scroll-margin-top: calc(var(--nav-height) + 2rem);
 }
 
-[data-theme="dark"] .cv-card {
-    background: oklch(16.5% 0 0);
-    box-shadow: 0 4px 48px oklch(0% 0 0 / 0.6);
-}
+/* ── Hero ────────────────────────────────── */
 
-/* ── Header ──────────────────────────────── */
-
-.cv-header {
+.cv-hero {
     display: grid;
     grid-template-columns: 1fr auto;
     align-items: start;
-    gap: 2rem;
-    padding: 3rem 3rem 2.5rem;
-    border-bottom: 1px solid var(--border);
-    background: var(--bg);
+    gap: 3rem;
+    padding: 2rem 0 4rem;
 }
 
-[data-theme="dark"] .cv-header {
-    background: oklch(15% 0 0);
-    border-bottom-color: oklch(30% 0 0);
-}
-
-.cv-header__identity {
+.cv-hero__text {
     min-width: 0;
-}
-
-.cv-header__meta-row {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.5rem;
 }
 
 .cv-name {
     font-family: var(--font-display);
-    font-size: clamp(2.5rem, 6vw, 4.25rem);
+    font-size: clamp(2.75rem, 7vw, 4.75rem);
     font-weight: 900;
     letter-spacing: -0.03em;
-    line-height: 1.05;
+    line-height: 1.02;
     color: var(--text);
 }
 
 .cv-subtitle {
-    margin-top: 0.75rem;
+    margin-top: 1rem;
     color: var(--text-muted);
-    font-family: var(--font-sans);
-    font-size: 0.875rem;
-    font-weight: 400;
-    letter-spacing: 0.03em;
+    font-size: 1.05rem;
+    font-weight: 500;
     line-height: 1.55;
-    max-width: 48ch;
+    max-width: 44ch;
 }
 
-.cv-header__contact {
+.cv-hero__profile {
+    margin-top: 1.75rem;
+}
+
+.cv-summary {
+    color: var(--text);
+    font-size: 1.0625rem;
+    line-height: 1.8;
+    max-width: 58ch;
+}
+
+.cv-hero__status {
     display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: 0.4rem;
-    padding-top: 0.35rem;
-    flex-shrink: 0;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 1.25rem;
+    margin-top: 1.75rem;
 }
 
-.cv-header__contact a,
+.cv-hero__links {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem 1.5rem;
+    margin-top: 1.1rem;
+}
+
+.cv-hero__links a,
 .cv-location {
     color: var(--text-muted);
     font-family: var(--font-mono);
-    font-size: 0.7rem;
+    font-size: 0.72rem;
     text-decoration: none;
     letter-spacing: 0.03em;
     transition: color 0.12s;
 }
 
-.cv-header__contact a:hover {
+.cv-hero__links a:hover {
     color: var(--accent);
     opacity: 1;
 }
 
-.cv-location {
+.cv-hero__media {
+    padding-top: 0.75rem;
+}
+
+.cv-portrait {
     display: block;
+    width: 168px;
+    height: 168px;
+    object-fit: cover;
+    border-radius: 12px;
+    border: 1px solid var(--border);
 }
 
 /* ── Availability badge ──────────────────── */
@@ -112,7 +111,6 @@
     display: inline-flex;
     align-items: center;
     gap: 0.45rem;
-    margin-top: 1rem;
     padding: 0.32rem 0.85rem 0.32rem 0.65rem;
     border-radius: 999px;
     border: 1px solid color-mix(in oklch, var(--accent) 30%, transparent);
@@ -149,165 +147,46 @@
     opacity: 0.6;
 }
 
-
-/* ── Scroll offset for fixed nav ─────────── */
-
-[id] {
-    scroll-margin-top: calc(var(--nav-height) + 3.5rem);
-}
-
-/* ── Body ────────────────────────────────── */
-
-.cv-body {
-    display: grid;
-    grid-template-columns: 280px 1fr;
-    align-items: start;
-}
-
-.cv-sidebar {
-    padding: 2.75rem 2rem 3.5rem 3rem;
-    border-right: 1px solid var(--border);
-    min-height: 100%;
-}
-
-[data-theme="dark"] .cv-sidebar {
-    background: oklch(15% 0 0);
-    border-right-color: oklch(28% 0 0);
-}
-
-.cv-main {
-    padding: 2.75rem 3rem 3.5rem 2.5rem;
-}
-
-/* ── Section ─────────────────────────────── */
+/* ── Sections ────────────────────────────── */
 
 .cv-section {
-    margin-bottom: 2.75rem;
+    margin-top: 4.5rem;
 }
 
-.cv-section:last-child {
-    margin-bottom: 0;
-}
-
-/* ── Section label ───────────────────────── */
-
-.cv-label {
-    display: flex;
-    align-items: center;
-    gap: 0.6rem;
-    margin-bottom: 1.1rem;
-    color: var(--accent);
-    font-family: var(--font-mono);
-    font-size: 0.62rem;
-    font-weight: 600;
-    letter-spacing: 0.14em;
-    text-transform: uppercase;
-    line-height: 1.4;
-}
-
-.cv-label::after {
-    content: '';
-    flex: 1;
-    height: 1px;
-    background: var(--border);
-}
-
-/* ── Profile ─────────────────────────────── */
-
-#profile.cv-section {
-    padding-bottom: 2.5rem;
-    margin-bottom: 2.5rem;
-    border-bottom: 1px solid var(--border);
-}
-
-.cv-profile-text {
+.cv-heading {
+    font-family: var(--font-display);
+    font-size: 1.4rem;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    line-height: 1.2;
     color: var(--text);
-    font-size: 1rem;
-    font-weight: 400;
-    line-height: 1.88;
-    max-width: 66ch;
+    margin-bottom: 1.5rem;
 }
 
-/* ── Experience cards ────────────────────── */
+/* ── Experience timeline ─────────────────── */
 
 .exp-item {
-    border: 1px solid var(--border);
-    border-top: 2px solid var(--accent);
-    border-radius: 5px;
-    margin-bottom: 0.875rem;
-    overflow: hidden;
-    transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+    display: grid;
+    grid-template-columns: 150px 1fr;
+    gap: 0.5rem 2.5rem;
+    padding: 1.75rem 0;
 }
 
-[data-theme="dark"] .exp-item {
-    background: oklch(18% 0 0);
+.exp-item + .exp-item {
+    border-top: 1px solid var(--border);
 }
 
-.exp-item:last-child {
-    margin-bottom: 0;
-}
-
-.exp-item:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 6px 24px oklch(0% 0 0 / 0.15);
-    border-top-color: var(--accent);
-}
-
-[data-theme="dark"] .exp-item:hover {
-    box-shadow: 0 8px 32px oklch(0% 0 0 / 0.4);
-}
-
-.exp-item__card-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 1rem;
-    padding: 1rem 1.35rem 0.85rem;
-    background: oklch(97% 0 0);
-    border-bottom: 1px solid var(--border);
-}
-
-[data-theme="dark"] .exp-item__card-header {
-    background: oklch(21% 0 0);
-    border-bottom-color: oklch(28% 0 0);
-}
-
-.exp-item__identity {
-    min-width: 0;
-}
-
-.exp-item__company {
-    font-family: var(--font-display);
-    font-size: 1.1rem;
-    font-weight: 800;
-    color: var(--text);
-    letter-spacing: -0.015em;
-    line-height: 1.2;
-}
-
-.exp-item__role {
-    margin-top: 0.3rem;
-    color: var(--accent);
-    font-family: var(--font-sans);
-    font-size: 0.8rem;
-    font-weight: 500;
-    line-height: 1.4;
-    letter-spacing: 0.01em;
-}
-
-.exp-item__meta {
+.exp-item__when {
     display: flex;
     flex-direction: column;
-    align-items: flex-end;
-    gap: 0.2rem;
-    flex-shrink: 0;
-    padding-top: 0.1rem;
+    gap: 0.3rem;
+    padding-top: 0.2rem;
 }
 
 .exp-item__period {
     color: var(--text-muted);
     font-family: var(--font-mono);
-    font-size: 0.63rem;
+    font-size: 0.68rem;
     letter-spacing: 0.06em;
     text-transform: uppercase;
     white-space: nowrap;
@@ -315,43 +194,63 @@
 
 .exp-item__location {
     color: var(--text-muted);
-    font-size: 0.65rem;
-    white-space: nowrap;
-    opacity: 0.7;
     font-family: var(--font-mono);
+    font-size: 0.68rem;
+    opacity: 0.7;
+    white-space: nowrap;
+}
+
+.exp-item__body {
+    min-width: 0;
+}
+
+.exp-item__company {
+    font-family: var(--font-display);
+    font-size: 1.125rem;
+    font-weight: 800;
+    color: var(--text);
+    letter-spacing: -0.015em;
+    line-height: 1.25;
+}
+
+.exp-item__role {
+    margin-top: 0.25rem;
+    color: var(--accent);
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1.4;
 }
 
 .exp-item__list {
-    margin: 0;
-    padding: 0.85rem 1.35rem 1rem 2.25rem;
+    margin: 0.85rem 0 0;
+    padding-left: 1.15rem;
     display: grid;
-    gap: 0.35rem;
+    gap: 0.4rem;
     color: var(--text-muted);
-    font-size: 0.83rem;
-    line-height: 1.65;
+    font-size: 0.9rem;
+    line-height: 1.7;
 }
 
-/* ── Skills ──────────────────────────────── */
+/* ── Skills band ─────────────────────────── */
+
+.skills-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 1.75rem 2.5rem;
+}
 
 .skill-entry {
     display: flex;
     flex-direction: column;
-    gap: 0.45rem;
-    padding: 0.75rem 0;
-    border-bottom: 1px solid var(--border);
-}
-
-.skill-entry:last-child {
-    border-bottom: none;
-    padding-bottom: 0;
+    gap: 0.55rem;
 }
 
 .skill-entry h3 {
     color: var(--text-muted);
     font-family: var(--font-mono);
-    font-size: 0.6rem;
+    font-size: 0.62rem;
     font-weight: 600;
-    letter-spacing: 0.1em;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
     line-height: 1.4;
 }
@@ -359,16 +258,16 @@
 .skill-chips {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.3rem;
+    gap: 0.35rem;
 }
 
 .skill-chip {
     display: inline-block;
-    padding: 0.18rem 0.55rem;
+    padding: 0.2rem 0.6rem;
     border: 1px solid var(--border);
-    border-radius: 3px;
+    border-radius: 4px;
     font-family: var(--font-mono);
-    font-size: 0.68rem;
+    font-size: 0.7rem;
     color: var(--text);
     letter-spacing: 0.01em;
     line-height: 1.6;
@@ -383,30 +282,31 @@
     background: color-mix(in oklch, var(--accent) 6%, transparent);
 }
 
-[data-theme="dark"] .skill-chip:hover {
-    background: color-mix(in oklch, var(--accent) 10%, transparent);
-}
-
 /* ── Contact ─────────────────────────────── */
 
-.cv-contact-section {
-    border-bottom: none;
-    margin-bottom: 0;
-    padding-bottom: 0;
+.cv-contact {
+    padding-top: 3.5rem;
+    border-top: 1px solid var(--border);
+}
+
+.cv-contact__heading {
+    font-size: clamp(1.5rem, 3.5vw, 2rem);
+    max-width: 24ch;
+    margin-bottom: 1rem;
 }
 
 .cv-contact-body {
     color: var(--text-muted);
-    font-size: 0.875rem;
+    font-size: 0.95rem;
     line-height: 1.75;
-    margin-bottom: 1.35rem;
+    margin-bottom: 1.75rem;
     max-width: 56ch;
 }
 
 .cv-cta {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.75rem;
+    gap: 1rem;
     align-items: center;
 }
 
@@ -426,6 +326,10 @@
     letter-spacing: 0.04em;
     text-transform: uppercase;
     transition: opacity 0.15s, transform 0.15s;
+}
+
+[data-theme="dark"] .btn-primary {
+    color: oklch(14% 0 0) !important;
 }
 
 .btn-primary:hover {
@@ -458,103 +362,50 @@
 
 @media (max-width: 760px) {
     .cv-page-main {
-        padding: 1.5rem 0.75rem 4rem;
+        padding: 1.5rem 1.25rem 4rem;
     }
 
-    .cv-header {
+    .cv-hero {
         grid-template-columns: 1fr;
-        gap: 1.5rem;
-        padding: 2rem 1.75rem 1.75rem;
+        gap: 1.75rem;
+        padding: 1rem 0 3rem;
     }
 
-    .cv-header__contact {
-        align-items: flex-start;
-    }
-
-    .cv-body {
-        grid-template-columns: 1fr;
-    }
-
-    .cv-main {
+    .cv-hero__media {
         order: -1;
+        padding-top: 0;
     }
 
-    .cv-sidebar {
-        padding: 2rem 1.75rem;
-        border-right: none;
-        border-bottom: 1px solid var(--border);
+    .cv-portrait {
+        width: 104px;
+        height: 104px;
     }
 
-    [data-theme="dark"] .cv-sidebar {
-        border-bottom-color: oklch(28% 0 0);
+    .cv-section {
+        margin-top: 3.5rem;
     }
 
-    .cv-main {
-        padding: 2rem 1.75rem;
+    .exp-item {
+        grid-template-columns: 1fr;
+        gap: 0.6rem;
+        padding: 1.5rem 0;
     }
 
-    .skill-chips {
-        gap: 0.25rem;
-    }
-}
-
-/* ── Mobile sidebar: chips can breathe wider ─ */
-
-@media (max-width: 760px) and (min-width: 481px) {
-    .skill-entry {
+    .exp-item__when {
         flex-direction: row;
-        align-items: flex-start;
-        gap: 0;
-    }
-
-    .skill-entry h3 {
-        flex: 0 0 120px;
-        padding-top: 0.22rem;
-    }
-
-    .skill-chips {
-        flex: 1;
+        align-items: center;
+        gap: 0.75rem;
+        padding-top: 0;
     }
 }
 
 /* ── Mobile ──────────────────────────────── */
 
 @media (max-width: 480px) {
-    .cv-page-main {
-        padding: 0.5rem 0 3rem;
-        background: var(--bg);
-    }
-
-    [data-theme="dark"] .cv-page-main {
-        background: oklch(8% 0 0);
-    }
-
-    .cv-card {
-        border-radius: 0;
-        box-shadow: none;
-    }
-
-    .cv-header {
-        padding: 1.5rem 1.25rem 1.35rem;
-    }
-
-    .cv-sidebar {
-        padding: 1.5rem 1.25rem;
-    }
-
-    .cv-main {
-        padding: 1.5rem 1.25rem;
-    }
-
-    .exp-item__card-header {
+    .cv-hero__links {
         flex-direction: column;
-        gap: 0.5rem;
-    }
-
-    .exp-item__meta {
         align-items: flex-start;
-        flex-direction: row;
-        gap: 0.75rem;
+        gap: 0.6rem;
     }
 
     .btn-primary {

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -365,20 +365,48 @@
         padding: 1.5rem 1.25rem 4rem;
     }
 
+    /* Avatar byline: portrait and name share row 1; the rest spans full width */
     .cv-hero {
-        grid-template-columns: 1fr;
-        gap: 1.75rem;
+        grid-template-columns: auto 1fr;
+        column-gap: 1rem;
+        row-gap: 0;
+        align-items: center;
         padding: 1rem 0 3rem;
     }
 
+    .cv-hero__text {
+        display: contents;
+    }
+
     .cv-hero__media {
-        order: -1;
+        grid-row: 1;
+        grid-column: 1;
+        align-self: center;
         padding-top: 0;
     }
 
     .cv-portrait {
-        width: 104px;
-        height: 104px;
+        width: 64px;
+        height: 64px;
+        border-radius: 50%;
+    }
+
+    .cv-name {
+        grid-row: 1;
+        grid-column: 2;
+        align-self: center;
+        font-size: clamp(1.9rem, 8vw, 2.6rem);
+    }
+
+    .cv-subtitle,
+    .cv-hero__profile,
+    .cv-hero__status,
+    .cv-hero__links {
+        grid-column: 1 / -1;
+    }
+
+    .cv-subtitle {
+        margin-top: 1.5rem;
     }
 
     .cv-section {

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -207,4 +207,22 @@ document.addEventListener('DOMContentLoaded', function() {
             });
     }
 
+    // ===== SKILLS SECTION STAGGERED REVEAL =====
+    const skillsSection = document.getElementById('skills');
+
+    if (skillsSection && 'IntersectionObserver' in window) {
+        skillsSection.classList.add('js-reveal-ready');
+
+        const skillsObserver = new IntersectionObserver(function(entries) {
+            entries.forEach(function(entry) {
+                if (entry.isIntersecting) {
+                    skillsSection.classList.add('is-revealed');
+                    skillsObserver.disconnect();
+                }
+            });
+        }, { threshold: 0.2 });
+
+        skillsObserver.observe(skillsSection);
+    }
+
 });

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -8,112 +8,103 @@
 {% endblock %}
 
 {% block main_inner %}
-<div class="cv-wrap">
-<div class="cv-card">
+<div class="cv-page">
 
-    <!-- ── Header: display name + contact ── -->
-    <header class="cv-header">
-        <div class="cv-header__identity">
+    <!-- ── Hero: identity, summary, contact ── -->
+    <header class="cv-hero" id="top">
+        <div class="cv-hero__text">
             <h1 class="cv-name">{{ config.name }}</h1>
-            <div class="cv-header__meta-row">
-                <p class="cv-subtitle">{{ config.tagline }}</p>
+            <p class="cv-subtitle">{{ config.tagline }}</p>
+
+            <section id="profile" class="cv-hero__profile" aria-label="Profile">
+                <p class="cv-summary">{{ cv.summary }}</p>
+            </section>
+
+            <div class="cv-hero__status">
                 <span class="cv-availability">
                     <span class="cv-availability__dot" aria-hidden="true"></span>
                     Available for work
                 </span>
+                <span class="cv-location">{{ config.location }}</span>
+            </div>
+
+            <div class="cv-hero__links" aria-label="Contact details">
+                <a href="mailto:{{ config.email }}">{{ config.email }}</a>
+                {% if config.phone %}
+                <a href="tel:{{ config.phone | replace(' ', '') }}">{{ config.phone }}</a>
+                {% endif %}
+                {% if config.linkedin_url %}
+                <a href="{{ config.linkedin_url }}" target="_blank" rel="noopener noreferrer" class="cv-social-link">
+                    {{ icon('linkedin', size=11) }}
+                    LinkedIn<span class="sr-only"> (opens in new tab)</span>
+                </a>
+                {% endif %}
+                {% if config.github_url %}
+                <a href="{{ config.github_url }}" target="_blank" rel="noopener noreferrer" class="cv-social-link">
+                    {{ icon('github', size=11) }}
+                    GitHub<span class="sr-only"> (opens in new tab)</span>
+                </a>
+                {% endif %}
+                {% if config.imdb_url %}
+                <a href="{{ config.imdb_url }}" target="_blank" rel="noopener noreferrer" class="cv-social-link">
+                    {{ icon('star', size=11) }}
+                    IMDb<span class="sr-only"> (opens in new tab)</span>
+                </a>
+                {% endif %}
             </div>
         </div>
-        <div class="cv-header__contact" aria-label="Contact details">
-            <a href="mailto:{{ config.email }}">{{ config.email }}</a>
-            {% if config.phone %}
-            <a href="tel:{{ config.phone | replace(' ', '') }}">{{ config.phone }}</a>
-            {% endif %}
-            {% if config.linkedin_url %}
-            <a href="{{ config.linkedin_url }}" target="_blank" rel="noopener noreferrer" class="cv-social-link">
-                {{ icon('linkedin', size=11) }}
-                LinkedIn<span class="sr-only"> (opens in new tab)</span>
-            </a>
-            {% endif %}
-            {% if config.github_url %}
-            <a href="{{ config.github_url }}" target="_blank" rel="noopener noreferrer" class="cv-social-link">
-                {{ icon('github', size=11) }}
-                GitHub<span class="sr-only"> (opens in new tab)</span>
-            </a>
-            {% endif %}
-            {% if config.imdb_url %}
-            <a href="{{ config.imdb_url }}" target="_blank" rel="noopener noreferrer" class="cv-social-link">
-                {{ icon('star', size=11) }}
-                IMDb<span class="sr-only"> (opens in new tab)</span>
-            </a>
-            {% endif %}
-            <span class="cv-location">{{ config.location }}</span>
+        <div class="cv-hero__media">
+            <img src="{{ url_for('static', filename='images/SreyeeshProfilePic.jpg') }}"
+                 alt="Portrait of {{ config.name }}" class="cv-portrait" width="168" height="168">
         </div>
     </header>
 
-    <!-- ── Body: sidebar + main ── -->
-    <div class="cv-body">
+    <!-- ── Experience: full-width timeline ── -->
+    <section id="experience" class="cv-section" aria-labelledby="exp-label">
+        <h2 id="exp-label" class="cv-heading">Experience</h2>
+        {% for item in cv.experience %}
+        <article class="exp-item">
+            <div class="exp-item__when">
+                <span class="exp-item__period">{{ item.period }}</span>
+                <span class="exp-item__location">{{ item.location }}</span>
+            </div>
+            <div class="exp-item__body">
+                <h3 class="exp-item__company">{{ item.company }}</h3>
+                <p class="exp-item__role">{{ item.role }}</p>
+                <ul class="exp-item__list">
+                    {% for h in item.highlights %}<li>{{ h }}</li>{% endfor %}
+                </ul>
+            </div>
+        </article>
+        {% endfor %}
+    </section>
 
-        <!-- Left sidebar: profile, skills, contact -->
-        <aside class="cv-sidebar">
-
-            <section id="profile" class="cv-section" aria-labelledby="profile-label">
-                <h2 id="profile-label" class="cv-label">Profile</h2>
-                <p class="cv-profile-text">{{ cv.summary }}</p>
-            </section>
-
-            <section id="skills" class="cv-section" aria-labelledby="skills-label">
-                <h2 id="skills-label" class="cv-label">Skills</h2>
-                {% for group in cv.skills %}
-                <div class="skill-entry">
-                    <h3>{{ group.group }}</h3>
-                    <div class="skill-chips">
-                        {% for item in group['items'] %}<span class="skill-chip">{{ item }}</span>{% endfor %}
-                    </div>
+    <!-- ── Skills: wide band of grouped chips ── -->
+    <section id="skills" class="cv-section" aria-labelledby="skills-label">
+        <h2 id="skills-label" class="cv-heading">Skills</h2>
+        <div class="skills-grid">
+            {% for group in cv.skills %}
+            <div class="skill-entry">
+                <h3>{{ group.group }}</h3>
+                <div class="skill-chips">
+                    {% for item in group['items'] %}<span class="skill-chip">{{ item }}</span>{% endfor %}
                 </div>
-                {% endfor %}
-            </section>
-
-            <section id="contact" class="cv-section cv-contact-section" aria-labelledby="contact-label">
-                <h2 id="contact-label" class="cv-label">{{ cv.contact_heading }}</h2>
-                <p class="cv-contact-body">{{ cv.contact_body }}</p>
-                <div class="cv-cta">
-                    <a class="btn-primary" href="mailto:{{ config.email }}">{{ config.email }}</a>
-                    {% if config.phone %}
-                    <a class="btn-ghost" href="tel:{{ config.phone | replace(' ', '') }}">{{ config.phone }}</a>
-                    {% endif %}
-                </div>
-            </section>
-
-        </aside>
-
-        <!-- Right main: experience -->
-        <div class="cv-main">
-
-            <section id="experience" class="cv-section" aria-labelledby="exp-label">
-                <h2 id="exp-label" class="cv-label">Experience</h2>
-                {% for item in cv.experience %}
-                <article class="exp-item">
-                    <div class="exp-item__card-header">
-                        <div class="exp-item__identity">
-                            <h3 class="exp-item__company">{{ item.company }}</h3>
-                            <p class="exp-item__role">{{ item.role }}</p>
-                        </div>
-                        <div class="exp-item__meta">
-                            <span class="exp-item__period">{{ item.period }}</span>
-                            <span class="exp-item__location">{{ item.location }}</span>
-                        </div>
-                    </div>
-                    <ul class="exp-item__list">
-                        {% for h in item.highlights %}<li>{{ h }}</li>{% endfor %}
-                    </ul>
-                </article>
-                {% endfor %}
-            </section>
-
+            </div>
+            {% endfor %}
         </div>
+    </section>
 
-    </div><!-- /.cv-body -->
+    <!-- ── Contact: closing CTA ── -->
+    <section id="contact" class="cv-section cv-contact" aria-labelledby="contact-label">
+        <h2 id="contact-label" class="cv-heading cv-contact__heading">{{ cv.contact_heading }}</h2>
+        <p class="cv-contact-body">{{ cv.contact_body }}</p>
+        <div class="cv-cta">
+            <a class="btn-primary" href="mailto:{{ config.email }}">{{ config.email }}</a>
+            {% if config.phone %}
+            <a class="btn-ghost" href="tel:{{ config.phone | replace(' ', '') }}">{{ config.phone }}</a>
+            {% endif %}
+        </div>
+    </section>
 
-</div><!-- /.cv-card -->
-</div><!-- /.cv-wrap -->
+</div>
 {% endblock %}

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -82,12 +82,15 @@
     <!-- ── Skills: wide band of grouped chips ── -->
     <section id="skills" class="cv-section" aria-labelledby="skills-label">
         <h2 id="skills-label" class="cv-heading">Skills</h2>
+        <div class="skills-core" aria-label="Core tools">
+            {% for item in cv.core_skills %}<span class="skill-chip skill-chip--core" style="--i: {{ loop.index0 }}">{{ item }}</span>{% endfor %}
+        </div>
         <div class="skills-grid">
             {% for group in cv.skills %}
-            <div class="skill-entry">
+            <div class="skill-entry" style="--g: {{ loop.index0 }}">
                 <h3>{{ group.group }}</h3>
                 <div class="skill-chips">
-                    {% for item in group['items'] %}<span class="skill-chip">{{ item }}</span>{% endfor %}
+                    {% for item in group['items'] %}<span class="skill-chip" style="--i: {{ loop.index0 }}">{{ item }}</span>{% endfor %}
                 </div>
             </div>
             {% endfor %}

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -20,6 +20,10 @@
                 <p class="cv-summary">{{ cv.summary }}</p>
             </section>
 
+            <p class="cv-studios" aria-label="Studios worked with">
+                {% for studio in cv.studio_strip %}<span>{{ studio }}</span>{% endfor %}
+            </p>
+
             <div class="cv-hero__status">
                 <span class="cv-availability">
                     <span class="cv-availability__dot" aria-hidden="true"></span>
@@ -79,6 +83,19 @@
         {% endfor %}
     </section>
 
+    <!-- ── Selected credits: shipped titles ── -->
+    <section id="credits" class="cv-section" aria-labelledby="credits-label">
+        <h2 id="credits-label" class="cv-heading">Selected credits</h2>
+        <ul class="credit-list">
+            {% for credit in cv.selected_credits %}
+            <li class="credit-item">
+                <span class="credit-item__title">{{ credit.title }}</span>
+                <span class="credit-item__studio">{{ credit.studio }}</span>
+            </li>
+            {% endfor %}
+        </ul>
+    </section>
+
     <!-- ── Skills: wide band of grouped chips ── -->
     <section id="skills" class="cv-section" aria-labelledby="skills-label">
         <h2 id="skills-label" class="cv-heading">Skills</h2>
@@ -95,6 +112,20 @@
             </div>
             {% endfor %}
         </div>
+    </section>
+
+    <!-- ── Education ── -->
+    <section id="education" class="cv-section" aria-labelledby="edu-label">
+        <h2 id="edu-label" class="cv-heading">Education</h2>
+        {% for entry in cv.education %}
+        <div class="edu-item">
+            <span class="edu-item__period">{{ entry.period }}</span>
+            <p class="edu-item__body">
+                <span class="edu-item__school">{{ entry.school }}</span>
+                <span class="edu-item__credential">{{ entry.credential }}</span>
+            </p>
+        </div>
+        {% endfor %}
     </section>
 
     <!-- ── Contact: closing CTA ── -->


### PR DESCRIPTION
## Summary
Implements #265 (impeccable critique P1: the proof is buried). Stacked on #264.

## Changes
- Quiet mono studio strip (Disney, Blizzard, DNEG, Boulder Media) under the hero summary, so seniority survives the first viewport
- Selected Credits section after Experience: Overwatch 2, My Little Pony: A New Generation, Garfield, each with studio attribution; titles only, no logos
- Education section after Skills from the previously-unrendered `education` data
- New `studio_strip` and `selected_credits` keys in `CV_PAGE`; no new nav links

flake8 clean, 23/23 tests pass.

Closes #265