### PR TITLE
feat(holding): Toucan Studios holding page (take CV homepage down)

### DIFF
--- a/app.py
+++ b/app.py
@@ -305,10 +305,12 @@ CV_PAGE = {
 
 @app.route('/')
 def home():
+    # Holding page while the Toucan Studios product landing is built.
+    # The CV landing (landing.html / CV_PAGE) is retained for the upcoming
+    # redesign but is not served or frozen during the holding period.
     return render_template(
-        'landing.html',
-        **build_page_context(page_slug='home', main_class='cv-page-main'),
-        cv=CV_PAGE,
+        'holding.html',
+        **build_page_context(page_slug='home'),
     )
 
 

--- a/freeze.py
+++ b/freeze.py
@@ -3,7 +3,6 @@ import shutil
 from pathlib import Path
 
 from app import SITE_CONFIG, app
-from blog import load_posts
 
 
 BUILD_DIR = Path('build')
@@ -40,16 +39,16 @@ def build_static_site() -> None:
     if Path('static').exists():
         shutil.copytree('static', BUILD_DIR / 'static')
 
-    posts = load_posts()
     original_base_path = app.config.get('SITE_BASE_PATH', '')
     app.config['SITE_BASE_PATH'] = normalized_base_path
 
     with app.app_context():
         with app.test_client() as client:
+            # Holding period: publish only the homepage holding page. The CV,
+            # about, and blog routes still exist in the app but are not frozen,
+            # so they are not live while the product landing is built.
             static_routes = [
                 ('/', BUILD_DIR / 'index.html'),
-                ('/blog/', BUILD_DIR / 'blog' / 'index.html'),
-                ('/about/', BUILD_DIR / 'about' / 'index.html'),
             ]
             for route, destination in static_routes:
                 response = client.get(route, follow_redirects=True)
@@ -57,15 +56,6 @@ def build_static_site() -> None:
                     raise RuntimeError(f'Failed to render {route}.')
                 write_file(destination, response.data.decode('utf-8'))
                 print(f"✅ Generated {destination.relative_to(BUILD_DIR)}")
-
-            for post in posts:
-                slug_route = f"/blog/{post['slug']}/"
-                response = client.get(slug_route)
-                if response.status_code != 200:
-                    raise RuntimeError(f'Failed to render {slug_route}.')
-                output_path = BUILD_DIR / 'blog' / post['slug'] / 'index.html'
-                write_file(output_path, response.data.decode('utf-8'))
-                print(f"✅ Generated blog/{post['slug']}/index.html")
 
     write_file(BUILD_DIR / '.nojekyll', '')
     app.config['SITE_BASE_PATH'] = original_base_path

--- a/static/css/holding.css
+++ b/static/css/holding.css
@@ -1,0 +1,462 @@
+/* Toucan Studios — holding page (standalone, not part of style.css) */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg:        #07080F;
+  --bg2:       #0D0F1E;
+  --surface:   #111326;
+  --border:    #1E2240;
+  --accent:    #4F8EF7;
+  --accent-2:  #7AADFF;
+  --glow:      rgba(79,142,247,0.18);
+  --purple:    #6C47C9;
+  --bright:    #E8EEFF;
+  --text:      #8A9CC8;
+  --muted:     #3D4A6A;
+}
+
+html, body {
+  min-height: 100%;
+  background: var(--bg);
+  color: var(--text);
+  font-family: 'Rajdhani', sans-serif;
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+}
+
+/* ---- Animated grid ---- */
+.grid-bg {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background-image:
+    linear-gradient(rgba(79,142,247,0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(79,142,247,0.04) 1px, transparent 1px);
+  background-size: 48px 48px;
+  animation: gridScroll 20s linear infinite;
+}
+
+@keyframes gridScroll {
+  0%   { background-position: 0 0; }
+  100% { background-position: 48px 48px; }
+}
+
+/* ---- Floating orbs ---- */
+.orb {
+  position: fixed;
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 0;
+  filter: blur(80px);
+  animation: orbFloat linear infinite;
+}
+
+.orb-1 {
+  width: 500px; height: 500px;
+  background: radial-gradient(circle, rgba(108,71,201,0.18) 0%, transparent 70%);
+  top: -10%; right: -5%;
+  animation-name: orbFloat1;
+  animation-duration: 18s;
+}
+
+.orb-2 {
+  width: 400px; height: 400px;
+  background: radial-gradient(circle, rgba(79,142,247,0.14) 0%, transparent 70%);
+  bottom: -10%; left: -5%;
+  animation-name: orbFloat2;
+  animation-duration: 22s;
+}
+
+.orb-3 {
+  width: 250px; height: 250px;
+  background: radial-gradient(circle, rgba(79,142,247,0.1) 0%, transparent 70%);
+  top: 40%; left: 30%;
+  animation-name: orbFloat3;
+  animation-duration: 14s;
+}
+
+@keyframes orbFloat1 {
+  0%,100% { transform: translate(0, 0) scale(1); }
+  33%      { transform: translate(-40px, 30px) scale(1.05); }
+  66%      { transform: translate(20px, -40px) scale(0.95); }
+}
+
+@keyframes orbFloat2 {
+  0%,100% { transform: translate(0, 0) scale(1); }
+  40%      { transform: translate(50px, -30px) scale(1.08); }
+  70%      { transform: translate(-20px, 40px) scale(0.95); }
+}
+
+@keyframes orbFloat3 {
+  0%,100% { transform: translate(0, 0) scale(1); opacity: 0.6; }
+  50%      { transform: translate(30px, -50px) scale(1.2); opacity: 1; }
+}
+
+/* ---- Scanline sweep ---- */
+.scanline {
+  position: fixed;
+  left: 0; right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, transparent 0%, rgba(79,142,247,0.15) 40%, rgba(79,142,247,0.3) 50%, rgba(79,142,247,0.15) 60%, transparent 100%);
+  pointer-events: none;
+  z-index: 0;
+  animation: scanSweep 8s ease-in-out infinite;
+}
+
+@keyframes scanSweep {
+  0%   { top: -2px; opacity: 0; }
+  5%   { opacity: 1; }
+  95%  { opacity: 1; }
+  100% { top: 100vh; opacity: 0; }
+}
+
+/* ---- Particle canvas ---- */
+#particles {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* ---- Watermark ---- */
+.watermark {
+  position: fixed;
+  bottom: -0.1em;
+  right: -0.04em;
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 900;
+  font-size: clamp(20vw, 28vw, 34vw);
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: transparent;
+  -webkit-text-stroke: 1px rgba(79,142,247,0.05);
+  user-select: none;
+  pointer-events: none;
+  z-index: 0;
+  animation: watermarkPulse 6s ease-in-out infinite;
+}
+
+@keyframes watermarkPulse {
+  0%,100% { -webkit-text-stroke: 1px rgba(79,142,247,0.05); }
+  50%      { -webkit-text-stroke: 1px rgba(79,142,247,0.1); }
+}
+
+/* ---- Page shell ---- */
+.page {
+  position: relative;
+  z-index: 1;
+  min-height: 100vh;
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 2.5rem;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+}
+
+/* ---- Top bar ---- */
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2.2rem 0 0;
+}
+
+.wordmark {
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 800;
+  font-size: 0.9rem;
+  letter-spacing: 0.1em;
+  color: var(--bright);
+  animation: wordmarkGlow 4s ease-in-out infinite;
+}
+
+.wordmark span { color: var(--accent); }
+
+@keyframes wordmarkGlow {
+  0%,100% { text-shadow: none; }
+  50%      { text-shadow: 0 0 20px rgba(79,142,247,0.3); }
+}
+
+.status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: 'Rajdhani', sans-serif;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+  border: 1px solid var(--border);
+  padding: 0.3rem 0.9rem;
+  border-radius: 3px;
+  animation: borderPulse 3s ease-in-out infinite;
+}
+
+@keyframes borderPulse {
+  0%,100% { border-color: var(--border); }
+  50%      { border-color: rgba(79,142,247,0.3); }
+}
+
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+  animation: dotPulse 2s ease-in-out infinite;
+}
+
+@keyframes dotPulse {
+  0%,100% { opacity: 1; box-shadow: 0 0 8px var(--accent); transform: scale(1); }
+  50%      { opacity: 0.4; box-shadow: 0 0 2px var(--accent); transform: scale(0.7); }
+}
+
+/* ---- Main ---- */
+.main {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 5rem 0 4rem;
+}
+
+/* ---- Eyebrow ---- */
+.eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 2rem;
+}
+
+.eyebrow-line {
+  width: 28px;
+  height: 1px;
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent);
+  animation: lineExpand 1.2s ease forwards 0.3s;
+  transform-origin: left;
+  transform: scaleX(0);
+}
+
+@keyframes lineExpand {
+  to { transform: scaleX(1); }
+}
+
+.eyebrow-text {
+  font-family: 'Rajdhani', sans-serif;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+/* ---- Headline ---- */
+.headline {
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 900;
+  font-size: clamp(2.2rem, 6vw, 4.8rem);
+  line-height: 1.08;
+  letter-spacing: -0.01em;
+  color: var(--bright);
+  margin-bottom: 0.5rem;
+  max-width: 760px;
+}
+
+/* Each line animates in separately */
+.headline .line {
+  display: block;
+  overflow: hidden;
+}
+
+.headline .line-inner {
+  display: block;
+  transform: translateY(100%);
+  animation: slideUp 0.7s cubic-bezier(0.16,1,0.3,1) forwards;
+}
+
+.headline .line:nth-child(1) .line-inner { animation-delay: 0.3s; }
+.headline .line:nth-child(2) .line-inner { animation-delay: 0.45s; }
+.headline .line:nth-child(3) .line-inner { animation-delay: 0.6s; }
+
+@keyframes slideUp {
+  to { transform: translateY(0); }
+}
+
+.headline .accent-word {
+  color: var(--accent);
+  text-shadow: 0 0 40px rgba(79,142,247,0.5);
+  animation: accentFlicker 5s ease-in-out infinite 1.5s;
+}
+
+@keyframes accentFlicker {
+  0%,90%,100% { text-shadow: 0 0 40px rgba(79,142,247,0.5); }
+  92%          { text-shadow: 0 0 20px rgba(79,142,247,0.2); }
+  94%          { text-shadow: 0 0 60px rgba(79,142,247,0.8); }
+  96%          { text-shadow: 0 0 30px rgba(79,142,247,0.3); }
+}
+
+/* ---- Divider ---- */
+.h-rule {
+  width: 0;
+  max-width: 580px;
+  height: 1px;
+  background: linear-gradient(90deg, var(--border) 0%, transparent 100%);
+  margin: 2.5rem 0;
+  animation: ruleGrow 1s ease forwards 0.9s;
+}
+
+@keyframes ruleGrow {
+  to { width: 100%; }
+}
+
+/* ---- Sub copy ---- */
+.sub {
+  font-family: 'Rajdhani', sans-serif;
+  font-size: 1.15rem;
+  font-weight: 400;
+  line-height: 1.75;
+  color: var(--text);
+  max-width: 480px;
+  margin-bottom: 3rem;
+  letter-spacing: 0.02em;
+}
+
+/* ---- Discipline tags ---- */
+.disciplines {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 3.5rem;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 0.38rem 0.9rem;
+  font-family: 'Rajdhani', sans-serif;
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: var(--text);
+  text-transform: uppercase;
+  transition: border-color 0.25s, color 0.25s, box-shadow 0.25s, transform 0.2s;
+  cursor: default;
+  opacity: 0;
+  animation: tagIn 0.4s ease forwards;
+}
+
+.tag:hover {
+  border-color: var(--accent);
+  color: var(--accent-2);
+  box-shadow: 0 0 12px rgba(79,142,247,0.2);
+  transform: translateY(-2px);
+}
+
+.tag.hot {
+  border-color: rgba(79,142,247,0.35);
+  color: var(--accent-2);
+  background: rgba(79,142,247,0.06);
+}
+
+.tag:nth-child(1) { animation-delay: 0.9s; }
+.tag:nth-child(2) { animation-delay: 1.0s; }
+.tag:nth-child(3) { animation-delay: 1.1s; }
+.tag:nth-child(4) { animation-delay: 1.2s; }
+.tag:nth-child(5) { animation-delay: 1.3s; }
+.tag:nth-child(6) { animation-delay: 1.4s; }
+.tag:nth-child(7) { animation-delay: 1.5s; }
+.tag:nth-child(8) { animation-delay: 1.6s; }
+
+@keyframes tagIn {
+  from { opacity: 0; transform: translateY(8px) scale(0.95); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+/* ---- Footer ---- */
+.footer {
+  border-top: 1px solid var(--border);
+  padding: 1.5rem 0 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.footer-copy {
+  font-family: 'Rajdhani', sans-serif;
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+}
+
+.footer-links { display: flex; gap: 1.5rem; }
+
+.footer-links a {
+  font-family: 'Rajdhani', sans-serif;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  text-decoration: none;
+  transition: color 0.15s, text-shadow 0.15s;
+}
+
+.footer-links a:hover {
+  color: var(--accent);
+  text-shadow: 0 0 10px rgba(79,142,247,0.4);
+}
+
+/* ---- Entrance animations ---- */
+.fu {
+  opacity: 0;
+  transform: translateY(14px);
+  animation: fu 0.6s ease forwards;
+}
+
+@keyframes fu { to { opacity: 1; transform: none; } }
+
+.d1 { animation-delay: 0.05s; }
+.d2 { animation-delay: 0.2s; }
+.d4 { animation-delay: 0.75s; }
+.d5 { animation-delay: 0.85s; }
+.d6 { animation-delay: 1.7s; }
+.d7 { animation-delay: 1.8s; }
+
+/* ---- Responsive ---- */
+@media (max-width: 580px) {
+  .page    { padding: 0 1.25rem; }
+  .topbar  { flex-direction: column; align-items: flex-start; gap: 0.75rem; }
+  .main    { padding: 3rem 0 2.5rem; }
+  .sub     { font-size: 1.08rem; margin-bottom: 2.25rem; }
+  .disciplines { margin-bottom: 2.5rem; }
+  .watermark { font-size: 42vw; }
+}
+
+@media (max-width: 380px) {
+  .page { padding: 0 1rem; }
+  .tag  { font-size: 0.76rem; padding: 0.34rem 0.7rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fu, .dot, .orb, .grid-bg, .scanline, .watermark,
+  .eyebrow-line, .h-rule, .tag, .headline .line-inner {
+    animation: none;
+    opacity: 1;
+    transform: none;
+    width: auto;
+  }
+  .headline .line-inner { transform: none; }
+  .eyebrow-line { width: 28px; }
+  .h-rule { width: 100%; }
+}

--- a/static/js/holding.js
+++ b/static/js/holding.js
@@ -1,0 +1,59 @@
+// Toucan Studios — holding page: floating particle field.
+(function () {
+  const canvas = document.getElementById('particles');
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+
+  function resize() {
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+  }
+  resize();
+  window.addEventListener('resize', resize);
+
+  const PARTICLE_COUNT = 55;
+  const particles = Array.from({ length: PARTICLE_COUNT }, () => ({
+    x: Math.random() * window.innerWidth,
+    y: Math.random() * window.innerHeight,
+    r: Math.random() * 1.4 + 0.3,
+    vx: (Math.random() - 0.5) * 0.3,
+    vy: (Math.random() - 0.5) * 0.3 - 0.1,
+    alpha: Math.random() * 0.5 + 0.1,
+    pulse: Math.random() * Math.PI * 2,
+  }));
+
+  function paint(animate) {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    particles.forEach((p) => {
+      p.pulse += 0.012;
+      const a = p.alpha * (0.6 + 0.4 * Math.sin(p.pulse));
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
+      ctx.fillStyle = `rgba(79,142,247,${a})`;
+      ctx.fill();
+
+      if (!animate) return;
+      p.x += p.vx;
+      p.y += p.vy;
+      if (p.x < -10) p.x = canvas.width + 10;
+      if (p.x > canvas.width + 10) p.x = -10;
+      if (p.y < -10) p.y = canvas.height + 10;
+      if (p.y > canvas.height + 10) p.y = -10;
+    });
+  }
+
+  const reduceMotion = window.matchMedia
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  if (reduceMotion) {
+    // Respect the user's preference: render a single static frame.
+    paint(false);
+    return;
+  }
+
+  function loop() {
+    paint(true);
+    requestAnimationFrame(loop);
+  }
+  requestAnimationFrame(loop);
+})();

--- a/templates/holding.html
+++ b/templates/holding.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{{ config.brand_name }} — Game Dev Mentoring</title>
+  <meta name="description" content="One-on-one mentoring for game developers, producers, and technical artists. {{ config.brand_legal_name }} — launching soon." />
+
+  <link rel="canonical" href="{{ canonical_url }}" />
+  <meta name="robots" content="noindex, follow" />
+
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="{{ config.brand_name }}" />
+  <meta property="og:title" content="{{ config.brand_name }} — Game Dev Mentoring" />
+  <meta property="og:description" content="One-on-one mentoring for game developers, producers, and technical artists. Launching soon." />
+  <meta property="og:url" content="{{ canonical_url }}" />
+  <meta property="og:image" content="{{ social_image_url }}" />
+  <meta name="twitter:card" content="summary_large_image" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;700;800;900&family=Rajdhani:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/holding.css', v=config.asset_version) }}" />
+</head>
+<body>
+
+  <!-- Animated background layers -->
+  <div class="grid-bg" aria-hidden="true"></div>
+  <div class="orb orb-1" aria-hidden="true"></div>
+  <div class="orb orb-2" aria-hidden="true"></div>
+  <div class="orb orb-3" aria-hidden="true"></div>
+  <div class="scanline" aria-hidden="true"></div>
+  <canvas id="particles" aria-hidden="true"></canvas>
+
+  <div class="watermark" aria-hidden="true">GG</div>
+
+  <div class="page">
+
+    <header class="topbar fu d1">
+      <div class="wordmark">TOUCAN<span>.</span>EE</div>
+      <div class="status"><span class="dot"></span> Launching soon</div>
+    </header>
+
+    <main class="main">
+
+      <div class="eyebrow fu d2">
+        <div class="eyebrow-line"></div>
+        <span class="eyebrow-text">1-on-1 Mentoring</span>
+      </div>
+
+      <h1 class="headline">
+        <span class="line"><span class="line-inner">Level up your</span></span>
+        <span class="line"><span class="line-inner accent-word">game dev</span></span>
+        <span class="line"><span class="line-inner">career.</span></span>
+      </h1>
+
+      <div class="h-rule"></div>
+
+      <p class="sub fu d4">
+        Mentoring for game developers, producers, and technical artists who want to sharpen their craft, ship better work, and grow in the industry.
+      </p>
+
+      <div class="disciplines">
+        <span class="tag hot">Game Development</span>
+        <span class="tag hot">Technical Art</span>
+        <span class="tag hot">Production</span>
+        <span class="tag">Godot</span>
+        <span class="tag">Unity</span>
+        <span class="tag">Unreal Engine</span>
+        <span class="tag">Portfolio Review</span>
+        <span class="tag">Career Planning</span>
+      </div>
+
+    </main>
+
+    <footer class="footer fu d7">
+      <span class="footer-copy">© {{ current_year }} {{ config.brand_legal_name }} — Estonia</span>
+      <nav class="footer-links">
+        <a href="mailto:{{ config.email }}">Email</a>
+      </nav>
+    </footer>
+
+  </div>
+
+  <script src="{{ url_for('static', filename='js/holding.js', v=config.asset_version) }}"></script>
+</body>
+</html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,31 +2,22 @@ from blog import load_posts
 
 
 def test_home_page(client):
-    """Home page loads the CV site."""
+    """Home page serves the Toucan Studios holding page."""
     response = client.get('/')
     assert response.status_code == 200
-    assert b'Sreyeesh Garimella' in response.data
+    assert b'Toucan Studios' in response.data
 
 
-def test_home_page_content(client):
-    """CV page shows the real positioning and core CV content."""
+def test_home_page_is_holding_page(client):
+    """During the build period the homepage is the holding page, not the CV."""
     response = client.get('/')
-    assert b'Sreyeesh Garimella' in response.data
-    assert b'Pipeline TD' in response.data
-    assert b'Python tooling' in response.data
-    assert b'DNEG' in response.data
-    assert b'Blizzard Entertainment' in response.data
-    assert b'Walt Disney Animation Studios' in response.data
-    assert b'1:1 game development mentoring' not in response.data
-    assert b'Tally' not in response.data
-
-
-def test_home_page_ignores_legacy_coming_soon_flag(client, monkeypatch):
-    """The old coming-soon gate must not replace the CV homepage."""
-    monkeypatch.setenv('SITE_COMING_SOON', 'true')
-    response = client.get('/')
-    assert b'Pipeline TD and Software Developer' in response.data
-    assert b'Get launch updates' not in response.data
+    body = response.data
+    assert b'Launching soon' in body
+    assert b'game dev' in body
+    assert b'1-on-1 Mentoring' in body
+    # The CV must no longer be live on the homepage.
+    assert b'Sreyeesh Garimella' not in body
+    assert b'DNEG' not in body
 
 
 def test_home_page_has_og_image(client):


### PR DESCRIPTION
Replaces the live CV homepage with a branded Toucan Studios 'launching soon' holding page while the product landing is built.

- Modularizes the provided standalone page: `templates/holding.html` + `static/css/holding.css` + `static/js/holding.js` (no inline CSS/JS), wired to config (brand, email, year, canonical, OG)
- Repoints `/` to the holding page; trims `freeze.py` to publish **only** the homepage, so the CV / about / blog pages are no longer live
- Mobile padding/spacing tightened; `prefers-reduced-motion` guard on the particle field; `noindex`

**Branched off `master` deliberately** (not `dev`) so this does not pull in the unshipped `dev` redesign. The full product landing ships from `dev` at the end of the sprint and replaces this.

Tests updated for the new homepage; flake8 + pytest green; freeze verified to output only `index.html`.