### PR TITLE
feat(holding): mentoring waitlist landing with Formspree signup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,8 +21,9 @@ SITE_GITHUB_URL=
 SITE_IMDB_URL=
 
 # Waitlist signup: full Formspree endpoint, e.g. https://formspree.io/f/abcdwxyz
-# Defaults to the live waitlist form in app.py; override here only to point at a
-# different form. Set to an empty value to fall back to the Flask /subscribe route.
+# Defaults to the live waitlist form in app.py. IMPORTANT: leave this empty in
+# local dev so the form posts to the Flask /subscribe route — otherwise test
+# signups go to the production Formspree inbox and burn the monthly quota.
 FORMSPREE_WAITLIST_ENDPOINT=
 
 # Database

--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,11 @@ SITE_LINKEDIN_URL=
 SITE_GITHUB_URL=
 SITE_IMDB_URL=
 
+# Waitlist signup: full Formspree endpoint, e.g. https://formspree.io/f/abcdwxyz
+# Defaults to the live waitlist form in app.py; override here only to point at a
+# different form. Set to an empty value to fall back to the Flask /subscribe route.
+FORMSPREE_WAITLIST_ENDPOINT=
+
 # Database
 DATABASE=
 DATABASE_PATH=

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ leads.json
 static/uploads/
 instance/newsletter.db
 instance/tutoring.sqlite
+instance/subscribers.csv
+subscribers.csv

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -6,37 +6,41 @@ brand
 
 ## Users
 
-Primary: VFX and animation studio hiring managers, pipeline supervisors, and technical directors evaluating a Pipeline TD or Production Technology Specialist candidate. They've been sent this URL and are scanning quickly for signal — real credits, technical depth, communication quality. They know what a pipeline person should know and will notice the difference between someone who sounds competent and someone who is.
+Primary: aspiring game and VFX developers, students, and early-career technical artists who want 1-on-1 mentoring. Many come from the weekly GameCity Kajaani sessions or similar game-dev communities. They are learning Python, version control, pipelines, and real production workflow, and they are evaluating whether this mentor is someone who has actually shipped games and films, speaks their language, and can get them unstuck. They scan fast and they can smell a sales funnel.
 
-Secondary: aspiring animation and game developers considering 1-on-1 mentoring. Less urgent now — the site is actively shifting toward job-hunting mode.
+Secondary: schools, programs, and community organizers who might refer or fund mentees. The founder's studio credits matter to them as a trust signal.
 
 ## Product Purpose
 
-Establish Sreyeesh Garimella as a credible, senior-level Pipeline TD candidate with serious production experience across Disney, Blizzard, DNEG, and others. Surface that experience clearly and let it do the persuading. The site should feel like it was built by someone who cares about craft and organization — which is exactly what hiring managers want in a pipeline person.
+This is the product landing for Toucan Studios, whose flagship offering is technical mentoring for game and VFX developers. The site exists to turn an interested visitor into a mentee: it leads with the mentoring offer, explains how it works, and uses real production credits (DNEG, Blizzard, Boulder Media, IMDb) plus weekly GameCity Kajaani mentoring as proof rather than as the headline.
 
-Success: a studio contact views the site and immediately understands what Sreyeesh does, what he has shipped, and why they should reach out.
+Success: a developer lands on the page, immediately understands what the mentoring is and who teaches it, trusts that the mentor has real shipped experience, and reaches out through the intake form or by email.
+
+Conversion is a request-a-session intake form (Formspree today, an owned Flask endpoint later) plus a direct email path. There is no scheduler and no fake scarcity.
 
 ## Brand Personality
 
-Quiet and precise. Confident without selling. Expertise proven through clarity, not claims. The kind of professional presence that doesn't need to convince you — the credits and consistency do the work.
+Energetic and game-native. This is a mentor who builds games and pipelines and clearly enjoys it, not a corporate training service. The voice is direct, technical, and encouraging, the way a good senior dev talks to a junior they actually want to see succeed. Confident because the work backs it up, never salesy.
 
-Three words: **precise, experienced, legible**
+Three words: **energetic, technical, approachable**
+
+The energy lives in typography, color, and purposeful motion, not in decorative effects. Bold and game-flavored, but disciplined.
 
 ## Anti-references
 
-- **Generic SaaS landing page:** hero metric cards, gradient text, identical icon grids, fake urgency banners ("Limited Availability"), conversion-optimized copy. The current index.html has this problem.
-- **Over-designed portfolio:** flashy scroll animations, WebGL backgrounds, cursor effects, parallax. Trying too hard, distracting from the work.
-- **Resume dumped on a page:** just a PDF translated to HTML with no organization or personality — sterile and forgettable.
-- **Creative agency aesthetic:** full-bleed imagery, big serif headlines, art-directed editorial layout. More for visual designers than Pipeline TDs.
+- **Generic SaaS landing page:** hero metric cards, gradient text, identical icon grids, fake urgency banners, conversion-optimized copy. Repels the exact audience it targets.
+- **Over-designed showpiece:** heavy WebGL, parallax, cursor effects, distracting scroll choreography, decorative particle fields and orbs for their own sake. Energy must come from craft, not gimmicks.
+- **Resume dumped on a page:** CV sections stacked with no narrative, hierarchy, or warmth. This is the current site's core problem and the thing the redesign must fix.
+- **Bootcamp or course-seller funnel:** aggressive "10x your skills" energy, countdown timers, testimonial-stuffed sales pages, pricing-tier pressure.
 
 ## Design Principles
 
-1. **Show, don't sell.** No urgency copy, no conversion tricks, no "Limited Availability" banners. Real credits at real studios persuade hiring managers; sales tactics repel them.
-2. **Expertise through clarity.** Organized, scannable information hierarchy signals technical competence. A Pipeline TD who can write clear docs and structure a system clearly is exactly what studios want.
-3. **Confidence without performance.** The person is the signal. No hero animations, no decorative chrome. Design should recede so the work comes forward.
-4. **Pipeline TD aesthetic.** The site should look like something a thoughtful technical person built — systematic, functional, uncluttered. Not a developer's default Bootstrap page, but not an art director's showpiece either.
-5. **Content before chrome.** Typography, spacing, and hierarchy matter more than color, illustration, or motion.
+1. **Offer first, proof second.** The mentoring value proposition leads. Studio credits and GameCity Kajaani mentoring are credibility that supports the offer, never the headline.
+2. **Speak the audience's language.** Game-dev and pipeline vocabulary, real tools, concrete outcomes. A developer should feel this was built by someone who does the work.
+3. **Energy through craft, not chrome.** Boldness comes from type scale, color commitment, and one or two purposeful motion moments, not from particle fields, parallax, or cursor tricks.
+4. **A landing, not a list.** Every section advances a narrative toward "request a session." No stacked-resume sections that just present data with no throughline.
+5. **Earn the click honestly.** No urgency, no scarcity, no funnel pressure. Clear value and a low-friction way to reach out.
 
 ## Accessibility & Inclusion
 
-WCAG AA minimum. Reduced motion already respected in base.css. Dark mode supported. Standard contrast ratios for body text and interactive elements.
+WCAG AA minimum. Respect `prefers-reduced-motion` (already honored in base.css) so all energetic motion has a calm fallback. Dark mode supported. Maintain contrast ratios for body text and interactive elements, especially for any bright accent color on dark surfaces.

--- a/app.py
+++ b/app.py
@@ -432,7 +432,9 @@ def subscribe():
     build, where there is no server to receive the POST.
     """
     email = request.form.get('email', '').strip().lower()
-    if len(email) > MAX_EMAIL_LEN or not EMAIL_RE.match(email):
+    # GDPR: storing the email needs explicit consent and a valid address.
+    consent = request.form.get('consent')
+    if not consent or len(email) > MAX_EMAIL_LEN or not EMAIL_RE.match(email):
         return redirect(url_for('home', subscribed='invalid', _anchor='signup'))
 
     path = _subscribers_path()
@@ -444,14 +446,24 @@ def subscribe():
     # Open with 0o600 at creation so the file is never briefly world-readable.
     # os.open's mode is masked by umask (can only drop bits); the chmod after
     # guarantees 0o600 even if the file already existed with looser perms.
+    # Record the consent timestamp alongside the email as proof of consent.
     fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
     with os.fdopen(fd, 'a', newline='', encoding='utf-8') as handle:
         csv.writer(handle).writerow(
-            [datetime.now(timezone.utc).isoformat(), _csv_safe(email)]
+            [datetime.now(timezone.utc).isoformat(), _csv_safe(email), 'consent']
         )
     os.chmod(path, 0o600)
 
     return redirect(url_for('home', subscribed='ok', _anchor='signup'))
+
+
+@app.route('/privacy/')
+def privacy():
+    """Standalone privacy notice for the waitlist signup (frozen for Pages)."""
+    return render_template(
+        'privacy.html',
+        **build_page_context(page_slug='privacy'),
+    )
 
 
 @app.route('/blog/')

--- a/app.py
+++ b/app.py
@@ -58,6 +58,14 @@ SITE_CONFIG = {
     'imdb_url': os.getenv('SITE_IMDB_URL', ''),
     'location': os.getenv('SITE_LOCATION', 'Estonia'),
     'launch_date': os.getenv('SITE_LAUNCH_DATE', '2026-05-31'),
+    # Formspree endpoint for the waitlist form (the live static build has no
+    # server, so the form posts here instead of the Flask /subscribe route).
+    # A Formspree form ID is public — it ships in the page HTML — so it is safe
+    # to keep as the default. Override with FORMSPREE_WAITLIST_ENDPOINT if the
+    # form ever changes.
+    'formspree_endpoint': os.getenv(
+        'FORMSPREE_WAITLIST_ENDPOINT', 'https://formspree.io/f/xdavvlor'
+    ),
 }
 
 NAV_LINKS = [

--- a/app.py
+++ b/app.py
@@ -1,8 +1,12 @@
+import csv
 import os
-from datetime import datetime
+import re
+from datetime import datetime, timezone
 
 from dotenv import load_dotenv
-from flask import Flask, abort, g, render_template, request, url_for
+from flask import (
+    Flask, abort, g, redirect, render_template, request, url_for,
+)
 from markupsafe import Markup
 
 load_dotenv()
@@ -303,6 +307,19 @@ CV_PAGE = {
 }
 
 
+# Basic email shape check. Not a deliverability guarantee, just enough to
+# reject obvious junk before it lands in the file.
+EMAIL_RE = re.compile(r'^[^@\s]+@[^@\s]+\.[^@\s]+$')
+
+
+def _subscribers_path() -> str:
+    """Where waitlist emails are stored. Override with SUBSCRIBERS_FILE."""
+    return os.getenv(
+        'SUBSCRIBERS_FILE',
+        os.path.join(app.instance_path, 'subscribers.csv'),
+    )
+
+
 @app.route('/')
 def home():
     # Holding page while the Toucan Studios product landing is built.
@@ -310,8 +327,42 @@ def home():
     # redesign but is not served or frozen during the holding period.
     return render_template(
         'holding.html',
-        **build_page_context(page_slug='home'),
+        **build_page_context(
+            page_slug='home',
+            subscribed=request.args.get('subscribed'),
+        ),
     )
+
+
+@app.route('/subscribe', methods=['POST'])
+def subscribe():
+    """Store a waitlist email, then redirect home with a status flag.
+
+    Note: this needs a running Flask server. It works in local dev and on
+    the planned self-hosted homelab, but NOT on the static GitHub Pages
+    build, where there is no server to receive the POST.
+    """
+    email = request.form.get('email', '').strip().lower()
+    if not EMAIL_RE.match(email):
+        return redirect(url_for('home', subscribed='invalid', _anchor='signup'))
+
+    path = _subscribers_path()
+    directory = os.path.dirname(path)
+    # Data dir: owner-only (rwx------), so other users on the box can't list it.
+    os.makedirs(directory, exist_ok=True)
+    os.chmod(directory, 0o700)
+
+    # Open with 0o600 at creation so the file is never briefly world-readable.
+    # os.open's mode is masked by umask (can only drop bits); the chmod after
+    # guarantees 0o600 even if the file already existed with looser perms.
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    with os.fdopen(fd, 'a', newline='', encoding='utf-8') as handle:
+        csv.writer(handle).writerow(
+            [datetime.now(timezone.utc).isoformat(), email]
+        )
+    os.chmod(path, 0o600)
+
+    return redirect(url_for('home', subscribed='ok', _anchor='signup'))
 
 
 @app.route('/blog/')

--- a/app.py
+++ b/app.py
@@ -315,6 +315,70 @@ CV_PAGE = {
 }
 
 
+# Holding-page content. Kept here (not in the template) so copy lives with the
+# other page constants and the template stays structural — see CLAUDE.md.
+HOLDING_PAGE = {
+    'marquee': [
+        'Game Development', 'Technical Art', 'Python Tooling', 'Git & Pipelines',
+        'Unreal', 'Unity', 'Godot', 'Portfolio Review', 'Career Planning',
+    ],
+    'hero_tags': [
+        {'label': 'Game Development', 'hot': True},
+        {'label': 'Technical Art', 'hot': True},
+        {'label': 'Production', 'hot': True},
+        {'label': 'Godot', 'hot': False},
+        {'label': 'Unity', 'hot': False},
+        {'label': 'Unreal Engine', 'hot': False},
+    ],
+    'curriculum': [
+        {
+            'title': 'Python for tools & automation',
+            'body': 'Write maintainable scripts and small tools that remove '
+                    'the boring parts of your workflow.',
+        },
+        {
+            'title': 'Git & version control',
+            'body': 'Branch, review, and collaborate the way real studios do, '
+                    'without fear of breaking things.',
+        },
+        {
+            'title': 'Production pipelines',
+            'body': 'Understand how assets, code, and tools move through a real '
+                    'game or VFX pipeline.',
+        },
+        {
+            'title': 'Game engines',
+            'body': 'Hands-on guidance in Unreal, Unity, or Godot, focused on '
+                    'shipping, not tutorials.',
+        },
+        {
+            'title': 'Technical art & DCC tools',
+            'body': 'Bridge art and engineering with the DCC and shader '
+                    'workflows studios actually use.',
+        },
+        {
+            'title': 'Portfolio & career',
+            'body': 'Honest portfolio reviews and a plan to get you closer to '
+                    'the role you want.',
+        },
+    ],
+    'proof': [
+        {
+            'label': 'DNEG · Blizzard · Boulder Media',
+            'detail': 'Feature animation & VFX production credits',
+        },
+        {
+            'label': 'Weekly mentor',
+            'detail': 'GameCity Kajaani game-dev sessions',
+        },
+        {
+            'label': 'IMDb-credited',
+            'detail': 'Shipped film & game work',
+        },
+    ],
+}
+
+
 # Basic email shape check. Not a deliverability guarantee, just enough to
 # reject obvious junk before it lands in the file.
 EMAIL_RE = re.compile(r'^[^@\s]+@[^@\s]+\.[^@\s]+$')
@@ -354,6 +418,7 @@ def home():
         **build_page_context(
             page_slug='home',
             subscribed=request.args.get('subscribed'),
+            holding=HOLDING_PAGE,
         ),
     )
 

--- a/app.py
+++ b/app.py
@@ -319,6 +319,10 @@ CV_PAGE = {
 # reject obvious junk before it lands in the file.
 EMAIL_RE = re.compile(r'^[^@\s]+@[^@\s]+\.[^@\s]+$')
 
+# RFC 5321 caps an email address at 254 characters; anything longer is junk and
+# would only bloat the file.
+MAX_EMAIL_LEN = 254
+
 
 def _subscribers_path() -> str:
     """Where waitlist emails are stored. Override with SUBSCRIBERS_FILE."""
@@ -326,6 +330,18 @@ def _subscribers_path() -> str:
         'SUBSCRIBERS_FILE',
         os.path.join(app.instance_path, 'subscribers.csv'),
     )
+
+
+def _csv_safe(value: str) -> str:
+    """Defang spreadsheet formula injection.
+
+    A cell beginning with =, +, -, @, or a tab is interpreted as a formula by
+    Excel/Sheets/LibreOffice. A crafted email like ``=HYPERLINK(...)@x.co``
+    passes the shape check, so prefix a single quote to force it to be text.
+    """
+    if value and value[0] in ('=', '+', '-', '@', '\t', '\r'):
+        return "'" + value
+    return value
 
 
 @app.route('/')
@@ -351,7 +367,7 @@ def subscribe():
     build, where there is no server to receive the POST.
     """
     email = request.form.get('email', '').strip().lower()
-    if not EMAIL_RE.match(email):
+    if len(email) > MAX_EMAIL_LEN or not EMAIL_RE.match(email):
         return redirect(url_for('home', subscribed='invalid', _anchor='signup'))
 
     path = _subscribers_path()
@@ -366,7 +382,7 @@ def subscribe():
     fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
     with os.fdopen(fd, 'a', newline='', encoding='utf-8') as handle:
         csv.writer(handle).writerow(
-            [datetime.now(timezone.utc).isoformat(), email]
+            [datetime.now(timezone.utc).isoformat(), _csv_safe(email)]
         )
     os.chmod(path, 0o600)
 

--- a/freeze.py
+++ b/freeze.py
@@ -49,6 +49,7 @@ def build_static_site() -> None:
             # so they are not live while the product landing is built.
             static_routes = [
                 ('/', BUILD_DIR / 'index.html'),
+                ('/privacy/', BUILD_DIR / 'privacy' / 'index.html'),
             ]
             for route, destination in static_routes:
                 response = client.get(route, follow_redirects=True)

--- a/static/css/holding.css
+++ b/static/css/holding.css
@@ -474,6 +474,29 @@ body {
   box-shadow: 0 0 0 3px rgba(16,185,129,0.2);
 }
 
+/* Consent checkbox — left-aligned even though the form is centred. */
+.signup-consent {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  margin-top: 1rem;
+  text-align: left;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--text);
+}
+
+.signup-consent input {
+  flex: none;
+  width: 1.1rem;
+  height: 1.1rem;
+  margin-top: 0.15rem;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.signup-consent a { color: var(--accent-2); }
+
 .signup-note {
   margin-top: 0.85rem;
   font-size: 0.82rem;
@@ -499,6 +522,29 @@ body {
   opacity: 0;
   pointer-events: none;
 }
+
+/* ── Legal / prose (privacy notice) ── */
+.legal { max-width: 680px; }
+.legal .section-title { max-width: none; margin: 0.4rem 0 1.5rem; }
+
+.legal p {
+  margin-bottom: 1.1rem;
+  font-size: 1.02rem;
+  line-height: 1.7;
+  color: var(--text);
+}
+
+.legal h2 {
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 600;
+  font-size: 1.1rem;
+  color: var(--bright);
+  margin: 2rem 0 0.6rem;
+}
+
+.legal a { color: var(--accent-2); }
+
+.legal-meta { font-size: 0.85rem; color: var(--muted); }
 
 /* ── Footer ── */
 .footer {

--- a/static/css/holding.css
+++ b/static/css/holding.css
@@ -488,6 +488,17 @@ body {
 
 .signup-status.is-ok { color: var(--accent-2); }
 .signup-status.is-err { color: #ff6b6b; }
+.signup-status[hidden] { display: none; }
+
+/* Formspree honeypot — kept out of view and out of the tab order. */
+.signup-hp {
+  position: absolute;
+  left: -9999px;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
 
 /* ── Footer ── */
 .footer {

--- a/static/css/holding.css
+++ b/static/css/holding.css
@@ -1,191 +1,86 @@
-/* Toucan Studios — holding page (standalone, not part of style.css) */
+/* Toucan Studios — pre-launch waitlist landing (standalone, not part of style.css)
+   Dark, premium, "workshop landing" aesthetic: Orbitron/Rajdhani, blue signal,
+   alternating sections, glowing CTAs, scroll-reveal. */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 :root {
-  --bg:        #07080F;
-  --bg2:       #0D0F1E;
+  --bg:        #07080f;
+  --bg-alt:    #0b0d1a;
   --surface:   #111326;
-  --border:    #1E2240;
-  --accent:    #4F8EF7;
-  --accent-2:  #7AADFF;
-  --glow:      rgba(79,142,247,0.18);
-  --purple:    #6C47C9;
-  --bright:    #E8EEFF;
-  --text:      #8A9CC8;
-  --muted:     #3D4A6A;
+  --surface-2: #161a30;
+  --border:    #20254a;
+  --accent:    #10b981;
+  --accent-2:  #34d399;
+  --bright:    #eef3ff;
+  --text:      #93a3c9;
+  --muted:     #5a6890;
 }
 
-html, body {
-  min-height: 100%;
+html { scroll-behavior: smooth; }
+
+body {
   background: var(--bg);
   color: var(--text);
   font-family: 'Rajdhani', sans-serif;
   font-size: 16px;
+  line-height: 1.6;
   -webkit-font-smoothing: antialiased;
   overflow-x: hidden;
 }
 
-/* ---- Animated grid ---- */
-.grid-bg {
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  z-index: 0;
-  background-image:
-    linear-gradient(rgba(79,142,247,0.04) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(79,142,247,0.04) 1px, transparent 1px);
-  background-size: 48px 48px;
-  animation: gridScroll 20s linear infinite;
-}
-
-@keyframes gridScroll {
-  0%   { background-position: 0 0; }
-  100% { background-position: 48px 48px; }
-}
-
-/* ---- Floating orbs ---- */
-.orb {
-  position: fixed;
-  border-radius: 50%;
-  pointer-events: none;
-  z-index: 0;
-  filter: blur(80px);
-  animation: orbFloat linear infinite;
-}
-
-.orb-1 {
-  width: 500px; height: 500px;
-  background: radial-gradient(circle, rgba(108,71,201,0.18) 0%, transparent 70%);
-  top: -10%; right: -5%;
-  animation-name: orbFloat1;
-  animation-duration: 18s;
-}
-
-.orb-2 {
-  width: 400px; height: 400px;
-  background: radial-gradient(circle, rgba(79,142,247,0.14) 0%, transparent 70%);
-  bottom: -10%; left: -5%;
-  animation-name: orbFloat2;
-  animation-duration: 22s;
-}
-
-.orb-3 {
-  width: 250px; height: 250px;
-  background: radial-gradient(circle, rgba(79,142,247,0.1) 0%, transparent 70%);
-  top: 40%; left: 30%;
-  animation-name: orbFloat3;
-  animation-duration: 14s;
-}
-
-@keyframes orbFloat1 {
-  0%,100% { transform: translate(0, 0) scale(1); }
-  33%      { transform: translate(-40px, 30px) scale(1.05); }
-  66%      { transform: translate(20px, -40px) scale(0.95); }
-}
-
-@keyframes orbFloat2 {
-  0%,100% { transform: translate(0, 0) scale(1); }
-  40%      { transform: translate(50px, -30px) scale(1.08); }
-  70%      { transform: translate(-20px, 40px) scale(0.95); }
-}
-
-@keyframes orbFloat3 {
-  0%,100% { transform: translate(0, 0) scale(1); opacity: 0.6; }
-  50%      { transform: translate(30px, -50px) scale(1.2); opacity: 1; }
-}
-
-/* ---- Particle canvas ---- */
-#particles {
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  z-index: 0;
-}
-
-/* ---- Watermark ---- */
-.watermark {
-  position: fixed;
-  bottom: -0.1em;
-  right: -0.04em;
-  font-family: 'Orbitron', sans-serif;
-  font-weight: 900;
-  font-size: clamp(20vw, 28vw, 34vw);
-  line-height: 1;
-  letter-spacing: -0.02em;
-  color: transparent;
-  -webkit-text-stroke: 1px rgba(79,142,247,0.05);
-  user-select: none;
-  pointer-events: none;
-  z-index: 0;
-  animation: watermarkPulse 6s ease-in-out infinite;
-}
-
-@keyframes watermarkPulse {
-  0%,100% { -webkit-text-stroke: 1px rgba(79,142,247,0.05); }
-  50%      { -webkit-text-stroke: 1px rgba(79,142,247,0.1); }
-}
-
-/* ---- Page shell ---- */
-.page {
-  position: relative;
-  z-index: 1;
-  min-height: 100vh;
-  max-width: 960px;
+.container {
+  width: 100%;
+  max-width: 1080px;
   margin: 0 auto;
-  padding: 0 2.5rem;
-  display: grid;
-  grid-template-rows: auto 1fr auto;
+  padding: 0 1.75rem;
 }
 
-/* ---- Top bar ---- */
-.topbar {
+/* ── Sticky nav ── */
+.nav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(7,8,15,0.78);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border);
+}
+
+.nav-inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 2.2rem 0 0;
+  height: 64px;
 }
 
 .wordmark {
   font-family: 'Orbitron', sans-serif;
   font-weight: 800;
-  font-size: 0.9rem;
+  font-size: 0.95rem;
   letter-spacing: 0.1em;
   color: var(--bright);
-  animation: wordmarkGlow 4s ease-in-out infinite;
+  text-decoration: none;
 }
 
 .wordmark span { color: var(--accent); }
 
-@keyframes wordmarkGlow {
-  0%,100% { text-shadow: none; }
-  50%      { text-shadow: 0 0 20px rgba(79,142,247,0.3); }
-}
+.nav-right { display: flex; align-items: center; gap: 1.25rem; }
 
 .status {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  font-family: 'Rajdhani', sans-serif;
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   font-weight: 600;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--muted);
-  border: 1px solid var(--border);
-  padding: 0.3rem 0.9rem;
-  border-radius: 3px;
-  animation: borderPulse 3s ease-in-out infinite;
-}
-
-@keyframes borderPulse {
-  0%,100% { border-color: var(--border); }
-  50%      { border-color: rgba(79,142,247,0.3); }
 }
 
 .dot {
-  width: 6px;
-  height: 6px;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
   background: var(--accent);
   box-shadow: 0 0 8px var(--accent);
@@ -193,213 +88,434 @@ html, body {
 }
 
 @keyframes dotPulse {
-  0%,100% { opacity: 1; box-shadow: 0 0 8px var(--accent); transform: scale(1); }
-  50%      { opacity: 0.4; box-shadow: 0 0 2px var(--accent); transform: scale(0.7); }
+  0%,100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.4; transform: scale(0.65); }
 }
 
-/* ---- Main ---- */
-.main {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  padding: 5rem 0 4rem;
+.nav-cta {
+  font-family: 'Rajdhani', sans-serif;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--bright);
+  text-decoration: none;
+  padding: 0.5rem 1.1rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  transition: border-color 0.2s, color 0.2s, background 0.2s;
 }
 
-/* ---- Eyebrow ---- */
+.nav-cta:hover {
+  border-color: var(--accent);
+  color: var(--accent-2);
+  background: rgba(16,185,129,0.08);
+}
+
+/* ── Marquee ── */
+.marquee {
+  overflow: hidden;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-alt);
+  padding: 0.6rem 0;
+}
+
+.marquee-track {
+  display: inline-flex;
+  align-items: center;
+  gap: 1.25rem;
+  white-space: nowrap;
+  animation: marquee 28s linear infinite;
+}
+
+.marquee-track span {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.marquee-track .sep { color: var(--accent); }
+
+@keyframes marquee {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-50%); }
+}
+
+/* ── Hero ── */
+.hero {
+  position: relative;
+  padding: clamp(4rem, 11vh, 8rem) 0 clamp(3.5rem, 8vh, 6rem);
+  overflow: hidden;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(60% 50% at 18% 12%, rgba(16,185,129,0.16) 0%, transparent 60%),
+    radial-gradient(50% 50% at 90% 0%, rgba(20,184,166,0.12) 0%, transparent 55%);
+}
+
+.hero-inner { position: relative; z-index: 1; max-width: 760px; }
+
 .eyebrow {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  margin-bottom: 2rem;
+  margin-bottom: 1.75rem;
 }
 
 .eyebrow-line {
-  width: 28px;
-  height: 1px;
+  width: 30px;
+  height: 2px;
   background: var(--accent);
-  box-shadow: 0 0 6px var(--accent);
-  animation: lineExpand 1.2s ease forwards 0.3s;
+  box-shadow: 0 0 8px var(--accent);
   transform-origin: left;
+  animation: lineExpand 1s ease forwards 0.2s;
   transform: scaleX(0);
 }
 
-@keyframes lineExpand {
-  to { transform: scaleX(1); }
-}
+@keyframes lineExpand { to { transform: scaleX(1); } }
 
 .eyebrow-text {
   font-family: 'Rajdhani', sans-serif;
-  font-size: 0.78rem;
-  font-weight: 600;
+  font-size: 0.8rem;
+  font-weight: 700;
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--accent);
 }
 
-/* ---- Headline ---- */
 .headline {
   font-family: 'Orbitron', sans-serif;
   font-weight: 900;
-  font-size: clamp(2.2rem, 6vw, 4.8rem);
-  line-height: 1.08;
+  font-size: clamp(2.4rem, 7vw, 5rem);
+  line-height: 1.06;
   letter-spacing: -0.01em;
   color: var(--bright);
-  margin-bottom: 0.5rem;
-  max-width: 760px;
 }
 
-/* Each line animates in separately */
-.headline .line {
-  display: block;
-  overflow: hidden;
-}
+.headline .line { display: block; overflow: hidden; }
 
 .headline .line-inner {
   display: block;
-  transform: translateY(100%);
-  animation: slideUp 0.7s cubic-bezier(0.16,1,0.3,1) forwards;
+  transform: translateY(110%);
+  animation: rise 0.75s cubic-bezier(0.16,1,0.3,1) forwards;
 }
 
-.headline .line:nth-child(1) .line-inner { animation-delay: 0.3s; }
-.headline .line:nth-child(2) .line-inner { animation-delay: 0.45s; }
-.headline .line:nth-child(3) .line-inner { animation-delay: 0.6s; }
+.headline .line:nth-child(1) .line-inner { animation-delay: 0.25s; }
+.headline .line:nth-child(2) .line-inner { animation-delay: 0.38s; }
+.headline .line:nth-child(3) .line-inner { animation-delay: 0.51s; }
 
-@keyframes slideUp {
-  to { transform: translateY(0); }
-}
+@keyframes rise { to { transform: translateY(0); } }
 
-.headline .accent-word {
+.accent-word {
   color: var(--accent);
-  text-shadow: 0 0 40px rgba(79,142,247,0.5);
-  animation: accentFlicker 5s ease-in-out infinite 1.5s;
+  text-shadow: 0 0 42px rgba(16,185,129,0.55);
 }
 
-@keyframes accentFlicker {
-  0%,90%,100% { text-shadow: 0 0 40px rgba(79,142,247,0.5); }
-  92%          { text-shadow: 0 0 20px rgba(79,142,247,0.2); }
-  94%          { text-shadow: 0 0 60px rgba(79,142,247,0.8); }
-  96%          { text-shadow: 0 0 30px rgba(79,142,247,0.3); }
-}
-
-/* ---- Divider ---- */
-.h-rule {
-  width: 0;
-  max-width: 580px;
-  height: 1px;
-  background: linear-gradient(90deg, var(--border) 0%, transparent 100%);
-  margin: 2.5rem 0;
-  animation: ruleGrow 1s ease forwards 0.9s;
-}
-
-@keyframes ruleGrow {
-  to { width: 100%; }
-}
-
-/* ---- Sub copy ---- */
-.sub {
-  font-family: 'Rajdhani', sans-serif;
-  font-size: 1.15rem;
-  font-weight: 400;
-  line-height: 1.75;
+.hero-sub {
+  margin-top: 1.75rem;
+  max-width: 540px;
+  font-size: 1.18rem;
+  font-weight: 500;
+  line-height: 1.7;
   color: var(--text);
-  max-width: 480px;
-  margin-bottom: 3rem;
-  letter-spacing: 0.02em;
 }
 
-/* ---- Discipline tags ---- */
-.disciplines {
+.hero-cta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem 1.5rem;
+  margin-top: 2.5rem;
+}
+
+/* ── Buttons ── */
+.btn-glow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 3rem;
+  padding: 0.8rem 1.8rem;
+  border: none;
+  border-radius: 5px;
+  background: var(--accent);
+  color: #061018;
+  font-family: 'Rajdhani', sans-serif;
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  text-decoration: none;
+  cursor: pointer;
+  box-shadow: 0 0 0 0 rgba(16,185,129,0.5);
+  transition: transform 0.18s cubic-bezier(0.16,1,0.3,1), box-shadow 0.25s, background 0.2s;
+}
+
+.btn-glow:hover {
+  transform: translateY(-2px);
+  background: var(--accent-2);
+  box-shadow: 0 10px 34px -8px rgba(16,185,129,0.7);
+}
+
+.btn-glow:active { transform: translateY(0); }
+
+.btn-text {
+  font-family: 'Rajdhani', sans-serif;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text);
+  text-decoration: none;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 2px;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.btn-text:hover { color: var(--accent-2); border-color: var(--accent); }
+
+/* ── Tags ── */
+.tags {
+  list-style: none;
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  margin-bottom: 3.5rem;
+  margin-top: 2.75rem;
+  padding: 0;
 }
 
 .tag {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  background: var(--surface);
+  padding: 0.4rem 0.9rem;
   border: 1px solid var(--border);
   border-radius: 3px;
-  padding: 0.38rem 0.9rem;
-  font-family: 'Rajdhani', sans-serif;
-  font-size: 0.82rem;
+  background: var(--surface);
+  font-size: 0.78rem;
   font-weight: 600;
   letter-spacing: 0.06em;
-  color: var(--text);
   text-transform: uppercase;
-  transition: border-color 0.25s, color 0.25s, box-shadow 0.25s, transform 0.2s;
-  cursor: default;
-  opacity: 0;
-  animation: tagIn 0.4s ease forwards;
+  color: var(--text);
 }
 
-.tag:hover {
+.tag--hot {
+  border-color: rgba(16,185,129,0.35);
+  background: rgba(16,185,129,0.08);
+  color: var(--accent-2);
+}
+
+/* ── Sections ── */
+.section { padding: clamp(4rem, 9vh, 7rem) 0; }
+.section--alt { background: var(--bg-alt); border-block: 1px solid var(--border); }
+
+.kicker {
+  font-family: 'Rajdhani', sans-serif;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 0.9rem;
+}
+
+.section-title {
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.6rem, 3.5vw, 2.5rem);
+  line-height: 1.15;
+  letter-spacing: -0.01em;
+  color: var(--bright);
+  max-width: 18ch;
+}
+
+/* ── Curriculum grid ── */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.25rem;
+  margin-top: 2.75rem;
+}
+
+.card {
+  position: relative;
+  padding: 1.75rem 1.6rem 1.6rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  transition: transform 0.22s cubic-bezier(0.16,1,0.3,1), border-color 0.22s, background 0.22s;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(16,185,129,0.5);
+  background: var(--surface-2);
+}
+
+.card-num {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: var(--accent);
+}
+
+.card h3 {
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 600;
+  font-size: 1.08rem;
+  line-height: 1.25;
+  color: var(--bright);
+  margin: 0.85rem 0 0.6rem;
+}
+
+.card p {
+  font-size: 0.98rem;
+  line-height: 1.6;
+  color: var(--text);
+}
+
+/* ── Who's teaching you ── */
+.who {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: clamp(2rem, 5vw, 4rem);
+  align-items: center;
+}
+
+.who-media img {
+  width: 100%;
+  height: auto;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  display: block;
+}
+
+.who-text .section-title { margin: 0.4rem 0 1.25rem; max-width: 22ch; }
+
+.who-body {
+  font-size: 1.08rem;
+  line-height: 1.75;
+  color: var(--text);
+  max-width: 60ch;
+}
+
+.proof {
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+  margin-top: 2rem;
+  padding: 0;
+}
+
+.proof li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding-left: 1rem;
+  border-left: 2px solid var(--accent);
+}
+
+.proof strong {
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 600;
+  font-size: 0.98rem;
+  color: var(--bright);
+}
+
+.proof span {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+/* ── Waitlist ── */
+.waitlist { text-align: center; }
+.waitlist-inner { max-width: 620px; margin: 0 auto; }
+.waitlist .section-title { max-width: none; margin: 0 auto; }
+
+.waitlist-sub {
+  margin: 1rem auto 2rem;
+  max-width: 46ch;
+  font-size: 1.05rem;
+  color: var(--text);
+}
+
+.signup { max-width: 520px; margin: 0 auto; }
+
+.signup-row {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.signup-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 0.8rem 1rem;
+  font-family: 'Rajdhani', sans-serif;
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--bright);
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.signup-input::placeholder { color: var(--muted); }
+
+.signup-input:focus {
+  outline: none;
   border-color: var(--accent);
-  color: var(--accent-2);
-  box-shadow: 0 0 12px rgba(79,142,247,0.2);
-  transform: translateY(-2px);
+  box-shadow: 0 0 0 3px rgba(16,185,129,0.2);
 }
 
-.tag.hot {
-  border-color: rgba(79,142,247,0.35);
-  color: var(--accent-2);
-  background: rgba(79,142,247,0.06);
+.signup-note {
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  color: var(--muted);
 }
 
-.tag:nth-child(1) { animation-delay: 0.9s; }
-.tag:nth-child(2) { animation-delay: 1.0s; }
-.tag:nth-child(3) { animation-delay: 1.1s; }
-.tag:nth-child(4) { animation-delay: 1.2s; }
-.tag:nth-child(5) { animation-delay: 1.3s; }
-.tag:nth-child(6) { animation-delay: 1.4s; }
-.tag:nth-child(7) { animation-delay: 1.5s; }
-.tag:nth-child(8) { animation-delay: 1.6s; }
-
-@keyframes tagIn {
-  from { opacity: 0; transform: translateY(8px) scale(0.95); }
-  to   { opacity: 1; transform: translateY(0) scale(1); }
+.signup-status {
+  margin-top: 0.85rem;
+  font-size: 0.95rem;
+  font-weight: 700;
 }
 
-/* ---- Footer ---- */
+.signup-status.is-ok { color: var(--accent-2); }
+.signup-status.is-err { color: #ff6b6b; }
+
+/* ── Footer ── */
 .footer {
   border-top: 1px solid var(--border);
-  padding: 1.5rem 0 2rem;
+  padding: 1.75rem 0 2.25rem;
+}
+
+.footer-inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
-.footer-copy {
-  font-family: 'Rajdhani', sans-serif;
-  font-size: 0.78rem;
-  font-weight: 500;
-  letter-spacing: 0.05em;
-  color: var(--muted);
-}
-
-.footer-links { display: flex; gap: 1.5rem; }
+.footer-copy { font-size: 0.82rem; color: var(--muted); }
 
 .footer-links a {
-  font-family: 'Rajdhani', sans-serif;
-  font-size: 0.78rem;
+  font-size: 0.82rem;
   font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--muted);
+  color: var(--text);
   text-decoration: none;
-  transition: color 0.15s, text-shadow 0.15s;
+  transition: color 0.15s;
 }
 
-.footer-links a:hover {
-  color: var(--accent);
-  text-shadow: 0 0 10px rgba(79,142,247,0.4);
-}
+.footer-links a:hover { color: var(--accent-2); }
 
-/* ---- Entrance animations ---- */
+/* ── Entrance + scroll-reveal ── */
 .fu {
   opacity: 0;
   transform: translateY(14px);
@@ -408,37 +524,41 @@ html, body {
 
 @keyframes fu { to { opacity: 1; transform: none; } }
 
-.d1 { animation-delay: 0.05s; }
-.d2 { animation-delay: 0.2s; }
-.d4 { animation-delay: 0.75s; }
-.d5 { animation-delay: 0.85s; }
-.d6 { animation-delay: 1.7s; }
-.d7 { animation-delay: 1.8s; }
+.d4 { animation-delay: 0.7s; }
+.d5 { animation-delay: 0.82s; }
+.d6 { animation-delay: 0.94s; }
 
-/* ---- Responsive ---- */
-@media (max-width: 580px) {
-  .page    { padding: 0 1.25rem; }
-  .topbar  { flex-direction: column; align-items: flex-start; gap: 0.75rem; }
-  .main    { padding: 3rem 0 2.5rem; }
-  .sub     { font-size: 1.08rem; margin-bottom: 2.25rem; }
-  .disciplines { margin-bottom: 2.5rem; }
-  .watermark { font-size: 42vw; }
+.reveal {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 0.6s ease, transform 0.6s cubic-bezier(0.16,1,0.3,1);
 }
 
-@media (max-width: 380px) {
-  .page { padding: 0 1rem; }
-  .tag  { font-size: 0.76rem; padding: 0.34rem 0.7rem; }
+.reveal.is-visible { opacity: 1; transform: none; }
+
+/* ── Responsive ── */
+@media (max-width: 720px) {
+  .who { grid-template-columns: 1fr; }
+  .who-media { max-width: 160px; }
+  .nav-cta { display: none; }
 }
 
+@media (max-width: 560px) {
+  .container { padding: 0 1.25rem; }
+  .signup-row { flex-direction: column; }
+  .btn-glow { width: 100%; }
+  .hero-cta .btn-glow { width: 100%; }
+}
+
+/* ── Reduced motion ── */
 @media (prefers-reduced-motion: reduce) {
-  .fu, .dot, .orb, .grid-bg, .watermark,
-  .eyebrow-line, .h-rule, .tag, .headline .line-inner {
-    animation: none;
-    opacity: 1;
-    transform: none;
-    width: auto;
+  html { scroll-behavior: auto; }
+  .fu, .dot, .eyebrow-line, .headline .line-inner,
+  .marquee-track, .reveal {
+    animation: none !important;
+    transition: none !important;
+    opacity: 1 !important;
+    transform: none !important;
   }
-  .headline .line-inner { transform: none; }
-  .eyebrow-line { width: 28px; }
-  .h-rule { width: 100%; }
+  .eyebrow-line { width: 30px; }
 }

--- a/static/js/holding.js
+++ b/static/js/holding.js
@@ -54,7 +54,9 @@
       });
 
       if (response.ok) {
+        // Leave the button disabled so a happy visitor can't double-submit.
         form.reset();
+        if (button) button.textContent = 'Done';
         show("You're on the list. I'll email you at launch.", true);
         return;
       }
@@ -63,9 +65,9 @@
       const data = await response.json().catch(() => null);
       const detail = data && data.errors && data.errors[0] && data.errors[0].message;
       show(detail || 'That email didn’t look right. Mind trying again?', false);
+      if (button) button.disabled = false;
     } catch (err) {
       show('Something went wrong. Please email me instead.', false);
-    } finally {
       if (button) button.disabled = false;
     }
   });

--- a/static/js/holding.js
+++ b/static/js/holding.js
@@ -23,3 +23,50 @@
 
   items.forEach((el) => observer.observe(el));
 })();
+
+// Toucan Studios — holding page: AJAX-submit the waitlist form to Formspree
+// so the visitor stays on the page. Without JS (or fetch) the form just does a
+// normal POST and Formspree shows its own confirmation page.
+(function () {
+  const form = document.querySelector('form[data-formspree]');
+  if (!form || !window.fetch) return;
+
+  const status = form.querySelector('[data-signup-status]');
+  const button = form.querySelector('button[type="submit"]');
+
+  function show(message, ok) {
+    if (!status) return;
+    status.textContent = message;
+    status.classList.toggle('is-ok', ok);
+    status.classList.toggle('is-err', !ok);
+    status.hidden = false;
+  }
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (button) button.disabled = true;
+
+    try {
+      const response = await fetch(form.action, {
+        method: 'POST',
+        body: new FormData(form),
+        headers: { Accept: 'application/json' },
+      });
+
+      if (response.ok) {
+        form.reset();
+        show("You're on the list. I'll email you at launch.", true);
+        return;
+      }
+
+      // Formspree returns 422 with a JSON `errors` array for bad input.
+      const data = await response.json().catch(() => null);
+      const detail = data && data.errors && data.errors[0] && data.errors[0].message;
+      show(detail || 'That email didn’t look right. Mind trying again?', false);
+    } catch (err) {
+      show('Something went wrong. Please email me instead.', false);
+    } finally {
+      if (button) button.disabled = false;
+    }
+  });
+})();

--- a/static/js/holding.js
+++ b/static/js/holding.js
@@ -1,59 +1,25 @@
-// Toucan Studios — holding page: floating particle field.
+// Toucan Studios — holding page: reveal sections as they scroll into view.
 (function () {
-  const canvas = document.getElementById('particles');
-  if (!canvas) return;
-  const ctx = canvas.getContext('2d');
+  const items = document.querySelectorAll('.reveal');
+  if (!items.length) return;
 
-  function resize() {
-    canvas.width = window.innerWidth;
-    canvas.height = window.innerHeight;
-  }
-  resize();
-  window.addEventListener('resize', resize);
-
-  const PARTICLE_COUNT = 55;
-  const particles = Array.from({ length: PARTICLE_COUNT }, () => ({
-    x: Math.random() * window.innerWidth,
-    y: Math.random() * window.innerHeight,
-    r: Math.random() * 1.4 + 0.3,
-    vx: (Math.random() - 0.5) * 0.3,
-    vy: (Math.random() - 0.5) * 0.3 - 0.1,
-    alpha: Math.random() * 0.5 + 0.1,
-    pulse: Math.random() * Math.PI * 2,
-  }));
-
-  function paint(animate) {
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    particles.forEach((p) => {
-      p.pulse += 0.012;
-      const a = p.alpha * (0.6 + 0.4 * Math.sin(p.pulse));
-      ctx.beginPath();
-      ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
-      ctx.fillStyle = `rgba(79,142,247,${a})`;
-      ctx.fill();
-
-      if (!animate) return;
-      p.x += p.vx;
-      p.y += p.vy;
-      if (p.x < -10) p.x = canvas.width + 10;
-      if (p.x > canvas.width + 10) p.x = -10;
-      if (p.y < -10) p.y = canvas.height + 10;
-      if (p.y > canvas.height + 10) p.y = -10;
-    });
-  }
-
-  const reduceMotion = window.matchMedia
-    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-
-  if (reduceMotion) {
-    // Respect the user's preference: render a single static frame.
-    paint(false);
+  // No IntersectionObserver (or reduced motion handled in CSS): just show them.
+  if (!('IntersectionObserver' in window)) {
+    items.forEach((el) => el.classList.add('is-visible'));
     return;
   }
 
-  function loop() {
-    paint(true);
-    requestAnimationFrame(loop);
-  }
-  requestAnimationFrame(loop);
+  const observer = new IntersectionObserver(
+    (entries, obs) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('is-visible');
+          obs.unobserve(entry.target);
+        }
+      });
+    },
+    { rootMargin: '0px 0px -10% 0px', threshold: 0.15 }
+  );
+
+  items.forEach((el) => observer.observe(el));
 })();

--- a/templates/holding.html
+++ b/templates/holding.html
@@ -176,9 +176,19 @@
         <h2 class="section-title">Be first in line when mentoring opens.</h2>
         <p class="waitlist-sub">Join the waitlist and I'll email you once, the day it goes live. No spam.</p>
 
-        <!-- Posts to the Flask /subscribe route, which stores the email server-side.
-             Works in dev + the planned homelab; 404s on the static build (no server). -->
-        <form class="signup" id="signup" method="POST" action="{{ url_for('subscribe') }}">
+        {#
+          On the live static build there is no server, so the form posts to
+          Formspree when FORMSPREE_WAITLIST_ENDPOINT is set. In dev (or the
+          future homelab) without that env var it falls back to the Flask
+          /subscribe route. holding.js AJAX-submits when data-formspree is
+          present, so the visitor stays on the page.
+        #}
+        {% set signup_action = config.formspree_endpoint or url_for('subscribe') %}
+        <form class="signup" id="signup" method="POST" action="{{ signup_action }}"
+              {% if config.formspree_endpoint %}data-formspree{% endif %}>
+          <input type="hidden" name="_subject" value="New {{ config.brand_name }} waitlist signup" />
+          <!-- Formspree honeypot: bots fill this hidden field, humans never see it. -->
+          <input class="signup-hp" type="text" name="_gotcha" tabindex="-1" autocomplete="off" aria-hidden="true" />
           <div class="signup-row">
             <input class="signup-input" type="email" name="email" inputmode="email"
                    autocomplete="email" required placeholder="you@studio.com"
@@ -186,6 +196,8 @@
             <button class="btn-glow" type="submit">Notify me</button>
           </div>
           <p class="signup-note">One email at launch. Unsubscribe anytime.</p>
+          <!-- JS writes the AJAX result here; the block below is the no-JS / Flask fallback. -->
+          <p class="signup-status" role="status" aria-live="polite" data-signup-status hidden></p>
           {% if subscribed == 'ok' %}
           <p class="signup-status is-ok" role="status">You're on the list. I'll email you at launch.</p>
           {% elif subscribed == 'invalid' %}

--- a/templates/holding.html
+++ b/templates/holding.html
@@ -38,25 +38,12 @@
   <!-- ── Marquee ticker ── -->
   <div class="marquee" aria-hidden="true">
     <div class="marquee-track">
-      <span>Game Development</span><span class="sep">/</span>
-      <span>Technical Art</span><span class="sep">/</span>
-      <span>Python Tooling</span><span class="sep">/</span>
-      <span>Git &amp; Pipelines</span><span class="sep">/</span>
-      <span>Unreal</span><span class="sep">/</span>
-      <span>Unity</span><span class="sep">/</span>
-      <span>Godot</span><span class="sep">/</span>
-      <span>Portfolio Review</span><span class="sep">/</span>
-      <span>Career Planning</span><span class="sep">/</span>
-      <!-- duplicated for a seamless loop -->
-      <span>Game Development</span><span class="sep">/</span>
-      <span>Technical Art</span><span class="sep">/</span>
-      <span>Python Tooling</span><span class="sep">/</span>
-      <span>Git &amp; Pipelines</span><span class="sep">/</span>
-      <span>Unreal</span><span class="sep">/</span>
-      <span>Unity</span><span class="sep">/</span>
-      <span>Godot</span><span class="sep">/</span>
-      <span>Portfolio Review</span><span class="sep">/</span>
-      <span>Career Planning</span><span class="sep">/</span>
+      {# Looped twice so the track scrolls seamlessly. #}
+      {% for _ in range(2) %}
+        {% for term in holding.marquee %}
+        <span>{{ term }}</span><span class="sep">/</span>
+        {% endfor %}
+      {% endfor %}
     </div>
   </div>
 
@@ -87,12 +74,9 @@
         </div>
 
         <ul class="tags fu d6">
-          <li class="tag tag--hot">Game Development</li>
-          <li class="tag tag--hot">Technical Art</li>
-          <li class="tag tag--hot">Production</li>
-          <li class="tag">Godot</li>
-          <li class="tag">Unity</li>
-          <li class="tag">Unreal Engine</li>
+          {% for tag in holding.hero_tags %}
+          <li class="tag{% if tag.hot %} tag--hot{% endif %}">{{ tag.label }}</li>
+          {% endfor %}
         </ul>
       </div>
     </section>
@@ -103,36 +87,13 @@
         <p class="kicker">What you'll learn</p>
         <h2 class="section-title">Mentoring built around real production work.</h2>
         <div class="grid">
+          {% for item in holding.curriculum %}
           <article class="card reveal">
-            <span class="card-num">01</span>
-            <h3>Python for tools &amp; automation</h3>
-            <p>Write maintainable scripts and small tools that remove the boring parts of your workflow.</p>
+            <span class="card-num">{{ '%02d' | format(loop.index) }}</span>
+            <h3>{{ item.title }}</h3>
+            <p>{{ item.body }}</p>
           </article>
-          <article class="card reveal">
-            <span class="card-num">02</span>
-            <h3>Git &amp; version control</h3>
-            <p>Branch, review, and collaborate the way real studios do, without fear of breaking things.</p>
-          </article>
-          <article class="card reveal">
-            <span class="card-num">03</span>
-            <h3>Production pipelines</h3>
-            <p>Understand how assets, code, and tools move through a real game or VFX pipeline.</p>
-          </article>
-          <article class="card reveal">
-            <span class="card-num">04</span>
-            <h3>Game engines</h3>
-            <p>Hands-on guidance in Unreal, Unity, or Godot, focused on shipping, not tutorials.</p>
-          </article>
-          <article class="card reveal">
-            <span class="card-num">05</span>
-            <h3>Technical art &amp; DCC tools</h3>
-            <p>Bridge art and engineering with the DCC and shader workflows studios actually use.</p>
-          </article>
-          <article class="card reveal">
-            <span class="card-num">06</span>
-            <h3>Portfolio &amp; career</h3>
-            <p>Honest portfolio reviews and a plan to get you closer to the role you want.</p>
-          </article>
+          {% endfor %}
         </div>
       </div>
     </section>
@@ -153,18 +114,12 @@
             and VFX developers every week, and I want to do more of it.
           </p>
           <ul class="proof">
+            {% for item in holding.proof %}
             <li>
-              <strong>DNEG &middot; Blizzard &middot; Boulder Media</strong>
-              <span>Feature animation &amp; VFX production credits</span>
+              <strong>{{ item.label }}</strong>
+              <span>{{ item.detail }}</span>
             </li>
-            <li>
-              <strong>Weekly mentor</strong>
-              <span>GameCity Kajaani game-dev sessions</span>
-            </li>
-            <li>
-              <strong>IMDb-credited</strong>
-              <span>Shipped film &amp; game work</span>
-            </li>
+            {% endfor %}
           </ul>
         </div>
       </div>

--- a/templates/holding.html
+++ b/templates/holding.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{{ config.brand_name }} — Game Dev Mentoring</title>
-  <meta name="description" content="One-on-one mentoring for game developers, producers, and technical artists. {{ config.brand_legal_name }} — launching soon." />
+  <meta name="description" content="1-on-1 mentoring for game developers, producers, and technical artists. {{ config.brand_legal_name }} — launching soon. Join the waitlist." />
 
   <link rel="canonical" href="{{ canonical_url }}" />
   <meta name="robots" content="noindex, follow" />
@@ -12,74 +12,199 @@
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="{{ config.brand_name }}" />
   <meta property="og:title" content="{{ config.brand_name }} — Game Dev Mentoring" />
-  <meta property="og:description" content="One-on-one mentoring for game developers, producers, and technical artists. Launching soon." />
+  <meta property="og:description" content="1-on-1 mentoring for game developers, producers, and technical artists. Launching soon." />
   <meta property="og:url" content="{{ canonical_url }}" />
   <meta property="og:image" content="{{ social_image_url }}" />
   <meta name="twitter:card" content="summary_large_image" />
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;700;800;900&family=Rajdhani:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@500;600;700;800;900&family=Rajdhani:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="{{ url_for('static', filename='css/holding.css', v=config.asset_version) }}" />
 </head>
-<body>
+<body id="top">
 
-  <!-- Animated background layers -->
-  <div class="grid-bg" aria-hidden="true"></div>
-  <div class="orb orb-1" aria-hidden="true"></div>
-  <div class="orb orb-2" aria-hidden="true"></div>
-  <div class="orb orb-3" aria-hidden="true"></div>
-  <canvas id="particles" aria-hidden="true"></canvas>
-
-  <div class="watermark" aria-hidden="true">GG</div>
-
-  <div class="page">
-
-    <header class="topbar fu d1">
-      <div class="wordmark">TOUCAN<span>.</span>EE</div>
-      <div class="status"><span class="dot"></span> Launching soon</div>
-    </header>
-
-    <main class="main">
-
-      <div class="eyebrow fu d2">
-        <div class="eyebrow-line"></div>
-        <span class="eyebrow-text">1-on-1 Mentoring</span>
+  <!-- ── Sticky nav ── -->
+  <header class="nav">
+    <div class="container nav-inner">
+      <a class="wordmark" href="#top">TOUCAN<span>.</span>EE</a>
+      <div class="nav-right">
+        <span class="status"><span class="dot" aria-hidden="true"></span> Launching soon</span>
+        <a class="nav-cta" href="#waitlist">Join waitlist</a>
       </div>
+    </div>
+  </header>
 
-      <h1 class="headline">
-        <span class="line"><span class="line-inner">Level up your</span></span>
-        <span class="line"><span class="line-inner accent-word">game dev</span></span>
-        <span class="line"><span class="line-inner">career.</span></span>
-      </h1>
+  <!-- ── Marquee ticker ── -->
+  <div class="marquee" aria-hidden="true">
+    <div class="marquee-track">
+      <span>Game Development</span><span class="sep">/</span>
+      <span>Technical Art</span><span class="sep">/</span>
+      <span>Python Tooling</span><span class="sep">/</span>
+      <span>Git &amp; Pipelines</span><span class="sep">/</span>
+      <span>Unreal</span><span class="sep">/</span>
+      <span>Unity</span><span class="sep">/</span>
+      <span>Godot</span><span class="sep">/</span>
+      <span>Portfolio Review</span><span class="sep">/</span>
+      <span>Career Planning</span><span class="sep">/</span>
+      <!-- duplicated for a seamless loop -->
+      <span>Game Development</span><span class="sep">/</span>
+      <span>Technical Art</span><span class="sep">/</span>
+      <span>Python Tooling</span><span class="sep">/</span>
+      <span>Git &amp; Pipelines</span><span class="sep">/</span>
+      <span>Unreal</span><span class="sep">/</span>
+      <span>Unity</span><span class="sep">/</span>
+      <span>Godot</span><span class="sep">/</span>
+      <span>Portfolio Review</span><span class="sep">/</span>
+      <span>Career Planning</span><span class="sep">/</span>
+    </div>
+  </div>
 
-      <div class="h-rule"></div>
+  <main>
 
-      <p class="sub fu d4">
-        Mentoring for game developers, producers, and technical artists who want to sharpen their craft, ship better work, and grow in the industry.
-      </p>
+    <!-- ── Hero ── -->
+    <section class="hero">
+      <div class="container hero-inner">
+        <p class="eyebrow">
+          <span class="eyebrow-line" aria-hidden="true"></span>
+          <span class="eyebrow-text">1-on-1 Mentoring &middot; {{ config.brand_name }}</span>
+        </p>
 
-      <div class="disciplines">
-        <span class="tag hot">Game Development</span>
-        <span class="tag hot">Technical Art</span>
-        <span class="tag hot">Production</span>
-        <span class="tag">Godot</span>
-        <span class="tag">Unity</span>
-        <span class="tag">Unreal Engine</span>
-        <span class="tag">Portfolio Review</span>
-        <span class="tag">Career Planning</span>
+        <h1 class="headline">
+          <span class="line"><span class="line-inner">Level up your</span></span>
+          <span class="line"><span class="line-inner accent-word">game dev</span></span>
+          <span class="line"><span class="line-inner">career.</span></span>
+        </h1>
+
+        <p class="hero-sub fu d4">
+          Mentoring for game developers, producers, and technical artists who want to
+          sharpen their craft, ship better work, and grow in the industry.
+        </p>
+
+        <div class="hero-cta fu d5">
+          <a class="btn-glow" href="#waitlist">Join the waitlist</a>
+          <a class="btn-text" href="#learn">See what you'll learn</a>
+        </div>
+
+        <ul class="tags fu d6">
+          <li class="tag tag--hot">Game Development</li>
+          <li class="tag tag--hot">Technical Art</li>
+          <li class="tag tag--hot">Production</li>
+          <li class="tag">Godot</li>
+          <li class="tag">Unity</li>
+          <li class="tag">Unreal Engine</li>
+        </ul>
       </div>
+    </section>
 
-    </main>
+    <!-- ── What you'll learn ── -->
+    <section class="section" id="learn">
+      <div class="container">
+        <p class="kicker">What you'll learn</p>
+        <h2 class="section-title">Mentoring built around real production work.</h2>
+        <div class="grid">
+          <article class="card reveal">
+            <span class="card-num">01</span>
+            <h3>Python for tools &amp; automation</h3>
+            <p>Write maintainable scripts and small tools that remove the boring parts of your workflow.</p>
+          </article>
+          <article class="card reveal">
+            <span class="card-num">02</span>
+            <h3>Git &amp; version control</h3>
+            <p>Branch, review, and collaborate the way real studios do, without fear of breaking things.</p>
+          </article>
+          <article class="card reveal">
+            <span class="card-num">03</span>
+            <h3>Production pipelines</h3>
+            <p>Understand how assets, code, and tools move through a real game or VFX pipeline.</p>
+          </article>
+          <article class="card reveal">
+            <span class="card-num">04</span>
+            <h3>Game engines</h3>
+            <p>Hands-on guidance in Unreal, Unity, or Godot, focused on shipping, not tutorials.</p>
+          </article>
+          <article class="card reveal">
+            <span class="card-num">05</span>
+            <h3>Technical art &amp; DCC tools</h3>
+            <p>Bridge art and engineering with the DCC and shader workflows studios actually use.</p>
+          </article>
+          <article class="card reveal">
+            <span class="card-num">06</span>
+            <h3>Portfolio &amp; career</h3>
+            <p>Honest portfolio reviews and a plan to get you closer to the role you want.</p>
+          </article>
+        </div>
+      </div>
+    </section>
 
-    <footer class="footer fu d7">
+    <!-- ── Who's teaching you ── -->
+    <section class="section section--alt" id="mentor">
+      <div class="container who">
+        <div class="who-media reveal">
+          <img src="{{ url_for('static', filename='images/SreyeeshProfilePic.jpg') }}"
+               alt="Sreyeesh Garimella" width="220" height="220" loading="lazy" />
+        </div>
+        <div class="who-text reveal">
+          <p class="kicker">Who's teaching you</p>
+          <h2 class="section-title">Shipped at the studios. Now teaching the craft.</h2>
+          <p class="who-body">
+            I'm Sreyeesh, a Pipeline TD and production technology specialist who has built
+            tools and pipelines on feature animation and VFX productions. Now I mentor game
+            and VFX developers every week, and I want to do more of it.
+          </p>
+          <ul class="proof">
+            <li>
+              <strong>DNEG &middot; Blizzard &middot; Boulder Media</strong>
+              <span>Feature animation &amp; VFX production credits</span>
+            </li>
+            <li>
+              <strong>Weekly mentor</strong>
+              <span>GameCity Kajaani game-dev sessions</span>
+            </li>
+            <li>
+              <strong>IMDb-credited</strong>
+              <span>Shipped film &amp; game work</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Waitlist signup ── -->
+    <section class="section waitlist" id="waitlist">
+      <div class="container waitlist-inner reveal">
+        <h2 class="section-title">Be first in line when mentoring opens.</h2>
+        <p class="waitlist-sub">Join the waitlist and I'll email you once, the day it goes live. No spam.</p>
+
+        <!-- Posts to the Flask /subscribe route, which stores the email server-side.
+             Works in dev + the planned homelab; 404s on the static build (no server). -->
+        <form class="signup" id="signup" method="POST" action="{{ url_for('subscribe') }}">
+          <div class="signup-row">
+            <input class="signup-input" type="email" name="email" inputmode="email"
+                   autocomplete="email" required placeholder="you@studio.com"
+                   aria-label="Your email address" />
+            <button class="btn-glow" type="submit">Notify me</button>
+          </div>
+          <p class="signup-note">One email at launch. Unsubscribe anytime.</p>
+          {% if subscribed == 'ok' %}
+          <p class="signup-status is-ok" role="status">You're on the list. I'll email you at launch.</p>
+          {% elif subscribed == 'invalid' %}
+          <p class="signup-status is-err" role="status">That email didn't look right. Mind trying again?</p>
+          {% endif %}
+        </form>
+      </div>
+    </section>
+
+  </main>
+
+  <footer class="footer">
+    <div class="container footer-inner">
       <span class="footer-copy">© {{ current_year }} {{ config.brand_legal_name }} — Estonia</span>
       <nav class="footer-links">
-        <a href="mailto:{{ config.email }}">Email</a>
+        <a href="mailto:{{ config.email }}">{{ config.email }}</a>
       </nav>
-    </footer>
-
-  </div>
+    </div>
+  </footer>
 
   <script src="{{ url_for('static', filename='js/holding.js', v=config.asset_version) }}"></script>
 </body>

--- a/templates/holding.html
+++ b/templates/holding.html
@@ -150,6 +150,10 @@
                    aria-label="Your email address" />
             <button class="btn-glow" type="submit">Notify me</button>
           </div>
+          <label class="signup-consent">
+            <input type="checkbox" name="consent" value="yes" required />
+            <span>I agree to be emailed once when mentoring launches, and to {{ config.brand_name }} storing my email for that purpose. See the <a href="{{ url_for('privacy') }}">privacy notice</a>.</span>
+          </label>
           <p class="signup-note">One email at launch. Unsubscribe anytime.</p>
           <!-- JS writes the AJAX result here; the block below is the no-JS / Flask fallback. -->
           <p class="signup-status" role="status" aria-live="polite" data-signup-status hidden></p>

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Privacy Notice — {{ config.brand_name }}</title>
+  <meta name="description" content="How {{ config.brand_legal_name }} handles waitlist signups." />
+
+  <link rel="canonical" href="{{ canonical_url }}" />
+  <meta name="robots" content="noindex, follow" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@500;600;700;800;900&family=Rajdhani:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/holding.css', v=config.asset_version) }}" />
+</head>
+<body id="top">
+
+  <header class="nav">
+    <div class="container nav-inner">
+      <a class="wordmark" href="{{ url_for('home') }}">TOUCAN<span>.</span>EE</a>
+      <div class="nav-right">
+        <a class="nav-cta" href="{{ url_for('home') }}#waitlist">Back to waitlist</a>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section class="section">
+      <div class="container legal">
+        <p class="kicker">Privacy</p>
+        <h1 class="section-title">Waitlist privacy notice</h1>
+
+        <p>
+          This notice covers the one thing {{ config.brand_legal_name }} collects on this
+          site: the email address you give the launch waitlist. {{ config.brand_legal_name }}
+          (Estonia) is the data controller.
+        </p>
+
+        <h2>What is collected</h2>
+        <p>Your email address, plus the date and time you submitted it.</p>
+
+        <h2>Why, and the lawful basis</h2>
+        <p>
+          Solely to send you a single email when mentoring launches. The lawful basis is
+          your <strong>consent</strong>, given via the checkbox on the form. You can
+          withdraw it at any time.
+        </p>
+
+        <h2>Who processes it</h2>
+        <p>
+          The form is handled by <a href="https://formspree.io/legal/privacy-policy/" rel="noopener" target="_blank">Formspree</a>,
+          which stores submissions on {{ config.brand_legal_name }}'s behalf as a data
+          processor. No data is sold or used for advertising.
+        </p>
+
+        <h2>How long it is kept</h2>
+        <p>
+          Until launch emails have been sent, or until you ask for removal — whichever is
+          sooner. After that the waitlist is deleted.
+        </p>
+
+        <h2>Your rights</h2>
+        <p>
+          You can ask to access, correct, or erase your data, or withdraw consent, by
+          emailing <a href="mailto:{{ config.email }}">{{ config.email }}</a>. You may also
+          complain to the Estonian Data Protection Inspectorate (AKI).
+        </p>
+
+        <p class="legal-meta">Last updated {{ current_year }}.</p>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="container footer-inner">
+      <span class="footer-copy">© {{ current_year }} {{ config.brand_legal_name }} — Estonia</span>
+      <nav class="footer-links">
+        <a href="mailto:{{ config.email }}">{{ config.email }}</a>
+      </nav>
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -13,17 +13,32 @@ def test_subscribe_stores_email(client, tmp_path, monkeypatch):
     subs = tmp_path / 'subscribers.csv'
     monkeypatch.setenv('SUBSCRIBERS_FILE', str(subs))
 
-    response = client.post('/subscribe', data={'email': 'Dev@Studio.com'})
+    response = client.post(
+        '/subscribe', data={'email': 'Dev@Studio.com', 'consent': 'yes'}
+    )
 
     assert response.status_code == 302
     assert 'subscribed=ok' in response.headers['Location']
     assert subs.exists()
     stored = subs.read_text()
     assert 'dev@studio.com' in stored  # normalised to lowercase
+    assert 'consent' in stored  # consent recorded with the signup
 
     # Personal data file must be owner read/write only (rw-------).
     import stat
     assert stat.S_IMODE(subs.stat().st_mode) == 0o600
+
+
+def test_subscribe_requires_consent(client, tmp_path, monkeypatch):
+    """A valid email without consent is rejected and nothing is written."""
+    subs = tmp_path / 'subscribers.csv'
+    monkeypatch.setenv('SUBSCRIBERS_FILE', str(subs))
+
+    response = client.post('/subscribe', data={'email': 'dev@studio.com'})
+
+    assert response.status_code == 302
+    assert 'subscribed=invalid' in response.headers['Location']
+    assert not subs.exists()
 
 
 def test_subscribe_rejects_invalid_email(client, tmp_path, monkeypatch):
@@ -31,7 +46,9 @@ def test_subscribe_rejects_invalid_email(client, tmp_path, monkeypatch):
     subs = tmp_path / 'subscribers.csv'
     monkeypatch.setenv('SUBSCRIBERS_FILE', str(subs))
 
-    response = client.post('/subscribe', data={'email': 'not-an-email'})
+    response = client.post(
+        '/subscribe', data={'email': 'not-an-email', 'consent': 'yes'}
+    )
 
     assert response.status_code == 302
     assert 'subscribed=invalid' in response.headers['Location']
@@ -44,7 +61,9 @@ def test_subscribe_defangs_csv_formula_injection(client, tmp_path, monkeypatch):
     monkeypatch.setenv('SUBSCRIBERS_FILE', str(subs))
 
     # '=cmd@x.co' passes the shape check but is a spreadsheet-injection payload.
-    response = client.post('/subscribe', data={'email': '=cmd@x.co'})
+    response = client.post(
+        '/subscribe', data={'email': '=cmd@x.co', 'consent': 'yes'}
+    )
 
     assert response.status_code == 302
     assert 'subscribed=ok' in response.headers['Location']
@@ -59,11 +78,30 @@ def test_subscribe_rejects_overlong_email(client, tmp_path, monkeypatch):
     monkeypatch.setenv('SUBSCRIBERS_FILE', str(subs))
 
     huge = ('a' * 250) + '@x.co'  # > 254 chars
-    response = client.post('/subscribe', data={'email': huge})
+    response = client.post(
+        '/subscribe', data={'email': huge, 'consent': 'yes'}
+    )
 
     assert response.status_code == 302
     assert 'subscribed=invalid' in response.headers['Location']
     assert not subs.exists()
+
+
+def test_privacy_page_renders(client):
+    """The privacy notice page is served and covers consent + rights."""
+    response = client.get('/privacy/')
+    assert response.status_code == 200
+    body = response.data
+    assert b'privacy notice' in body.lower()
+    assert b'consent' in body.lower()
+    assert b'Formspree' in body
+
+
+def test_waitlist_form_has_consent_and_privacy_link(client):
+    """The signup form requires consent and links the privacy notice."""
+    body = client.get('/').data
+    assert b'name="consent"' in body
+    assert b'/privacy/' in body
 
 
 def test_subscribe_confirmation_renders_on_home(client):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -45,15 +45,16 @@ def test_subscribe_confirmation_renders_on_home(client):
 
 
 def test_home_page_is_holding_page(client):
-    """During the build period the homepage is the holding page, not the CV."""
+    """The homepage is the mentoring waitlist landing, not the CV/portfolio."""
     response = client.get('/')
     body = response.data
     assert b'Launching soon' in body
     assert b'game dev' in body
     assert b'1-on-1 Mentoring' in body
-    # The CV must no longer be live on the homepage.
-    assert b'Sreyeesh Garimella' not in body
-    assert b'DNEG' not in body
+    assert b'waitlist' in body
+    # It must not be the old CV/portfolio homepage.
+    assert b'Available for work' not in body
+    assert b'Selected credits' not in body
 
 
 def test_home_page_has_og_image(client):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -38,6 +38,34 @@ def test_subscribe_rejects_invalid_email(client, tmp_path, monkeypatch):
     assert not subs.exists()
 
 
+def test_subscribe_defangs_csv_formula_injection(client, tmp_path, monkeypatch):
+    """An email starting with a formula char is stored as text, not a formula."""
+    subs = tmp_path / 'subscribers.csv'
+    monkeypatch.setenv('SUBSCRIBERS_FILE', str(subs))
+
+    # '=cmd@x.co' passes the shape check but is a spreadsheet-injection payload.
+    response = client.post('/subscribe', data={'email': '=cmd@x.co'})
+
+    assert response.status_code == 302
+    assert 'subscribed=ok' in response.headers['Location']
+    stored = subs.read_text()
+    assert "'=cmd@x.co" in stored  # quote-prefixed so it is treated as text
+    assert ',=cmd@x.co' not in stored  # never written as a bare formula
+
+
+def test_subscribe_rejects_overlong_email(client, tmp_path, monkeypatch):
+    """An address past the RFC length cap is rejected and nothing is written."""
+    subs = tmp_path / 'subscribers.csv'
+    monkeypatch.setenv('SUBSCRIBERS_FILE', str(subs))
+
+    huge = ('a' * 250) + '@x.co'  # > 254 chars
+    response = client.post('/subscribe', data={'email': huge})
+
+    assert response.status_code == 302
+    assert 'subscribed=invalid' in response.headers['Location']
+    assert not subs.exists()
+
+
 def test_subscribe_confirmation_renders_on_home(client):
     """The home page shows the success message after a redirect."""
     response = client.get('/?subscribed=ok')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -44,6 +44,29 @@ def test_subscribe_confirmation_renders_on_home(client):
     assert b"You're on the list" in response.data
 
 
+def test_waitlist_posts_to_formspree_by_default(client):
+    """The waitlist form posts to the configured Formspree endpoint."""
+    body = client.get('/').data
+    assert b'https://formspree.io/f/xdavvlor' in body
+    assert b'data-formspree' in body
+
+
+def test_waitlist_falls_back_to_flask_route_when_endpoint_empty(monkeypatch):
+    """An empty FORMSPREE_WAITLIST_ENDPOINT reverts to the Flask /subscribe route."""
+    import importlib
+
+    import app as app_module
+
+    monkeypatch.setenv('FORMSPREE_WAITLIST_ENDPOINT', '')
+    importlib.reload(app_module)
+    app_module.app.config.update(TESTING=True)
+    client = app_module.app.test_client()
+
+    body = client.get('/').data
+    assert b'action="/subscribe"' in body
+    assert b'data-formspree' not in body
+
+
 def test_home_page_is_holding_page(client):
     """The homepage is the mentoring waitlist landing, not the CV/portfolio."""
     response = client.get('/')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,6 +8,42 @@ def test_home_page(client):
     assert b'Toucan Studios' in response.data
 
 
+def test_subscribe_stores_email(client, tmp_path, monkeypatch):
+    """A valid email is appended to the subscribers file with a timestamp."""
+    subs = tmp_path / 'subscribers.csv'
+    monkeypatch.setenv('SUBSCRIBERS_FILE', str(subs))
+
+    response = client.post('/subscribe', data={'email': 'Dev@Studio.com'})
+
+    assert response.status_code == 302
+    assert 'subscribed=ok' in response.headers['Location']
+    assert subs.exists()
+    stored = subs.read_text()
+    assert 'dev@studio.com' in stored  # normalised to lowercase
+
+    # Personal data file must be owner read/write only (rw-------).
+    import stat
+    assert stat.S_IMODE(subs.stat().st_mode) == 0o600
+
+
+def test_subscribe_rejects_invalid_email(client, tmp_path, monkeypatch):
+    """An invalid email is rejected and nothing is written."""
+    subs = tmp_path / 'subscribers.csv'
+    monkeypatch.setenv('SUBSCRIBERS_FILE', str(subs))
+
+    response = client.post('/subscribe', data={'email': 'not-an-email'})
+
+    assert response.status_code == 302
+    assert 'subscribed=invalid' in response.headers['Location']
+    assert not subs.exists()
+
+
+def test_subscribe_confirmation_renders_on_home(client):
+    """The home page shows the success message after a redirect."""
+    response = client.get('/?subscribed=ok')
+    assert b"You're on the list" in response.data
+
+
 def test_home_page_is_holding_page(client):
     """During the build period the homepage is the holding page, not the CV."""
     response = client.get('/')


### PR DESCRIPTION
Reworks the live holding page from an animated splash into a mentoring **waitlist landing**, and wires up a working email signup.

## What changed
- **Redesign** — replaced the particle/orb/grid splash with a sectioned landing: hero + glowing CTA, a six-card "what you'll learn" grid, a mentor proof section, and a waitlist signup. Swapped the canvas particle field for a lightweight `IntersectionObserver` scroll-reveal.
- **Palette** — accent shifted from electric blue to the brand **emerald** (`#10b981`).
- **Credits** — DNEG · Blizzard · Boulder Media (Disney removed).
- **Waitlist signup** — two paths:
  - **Formspree** (`https://formspree.io/f/xdavvlor`) is the committed default, so the live static GitHub Pages build (no server) works. `holding.js` AJAX-submits so the visitor stays on the page; degrades to a normal POST without JS. Honeypot + `_subject` fields included.
  - **Flask `/subscribe`** route (stores email + UTC timestamp to `instance/subscribers.csv`, `0o600`/`0o700` perms) is the fallback for dev and the future homelab, selected when `FORMSPREE_WAITLIST_ENDPOINT` is empty.
- **PRODUCT.md** — reframed from CV/job-hunting to mentoring-product positioning.

## Testing
- 27 tests pass, lint clean.
- Formspree form tested end-to-end — a real submission landed in the Formspree inbox.

## Notes / follow-ups
- The live site currently serves the older dark "gamer" holding page (shipped via #290/#292); this PR replaces it on merge + deploy.
- **GDPR not yet addressed** — a consent checkbox + `/privacy` note are still outstanding before this publicly collects EU emails. Deferred deliberately.