### PR TITLE
feat(construction): status-board redesign — deploy log, identity, contact links

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,7 +48,7 @@ SITE_CONFIG = {
     ),
     'asset_version': os.getenv('ASSET_VERSION', '1'),
     'social_image': os.getenv('SITE_SOCIAL_IMAGE', 'images/SreyeeshProfilePic.jpg'),
-    'github_url': os.getenv('SITE_GITHUB_URL', ''),
+    'github_url': os.getenv('SITE_GITHUB_URL', 'https://github.com/Sreyeesh'),
     'linkedin_url': os.getenv(
         'SITE_LINKEDIN_URL',
         'https://www.linkedin.com/in/sreyeeshgarimella',

--- a/static/css/construction.css
+++ b/static/css/construction.css
@@ -172,70 +172,121 @@ h1 {
 }
 
 .deploy-log {
-  max-width: 26rem;
+  max-width: 27rem;
   margin-top: clamp(1.75rem, 3.5vw, 2.75rem);
   border: 1px solid var(--line);
+  background: color-mix(in srgb, var(--text) 3.5%, transparent);
   font-family: var(--font-mono);
   font-size: 0.78rem;
 }
 
 .deploy-log-title {
   margin: 0;
-  padding: 0.55rem 1rem;
+  padding: 0.6rem 1.1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
   border-bottom: 1px solid var(--line);
   color: var(--muted);
-  font-size: 0.68rem;
+  font-size: 0.66rem;
   font-weight: 600;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
+}
+
+/* live indicator dot in the panel header */
+.deploy-log-title::after {
+  content: "";
+  width: 0.45rem;
+  height: 0.45rem;
+  flex: none;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent);
 }
 
 .deploy-log-list {
   margin: 0;
-  padding: 0.65rem 0;
+  padding: 0.75rem 0;
   list-style: none;
 }
 
 .log-item {
-  padding: 0.32rem 1rem;
-  display: grid;
-  grid-template-columns: 1.25rem 1fr auto;
+  padding: 0.38rem 1.1rem;
+  display: flex;
   align-items: baseline;
-  gap: 0.5rem;
+  gap: 0.6rem;
 }
 
 .log-mark {
+  flex: none;
+  order: 0;
+  width: 1.1rem;
   color: var(--muted);
 }
 
+.log-label {
+  flex: none;
+  order: 1;
+  letter-spacing: 0.01em;
+}
+
+/* dotted leader connecting label to state */
+.log-item::after {
+  content: "";
+  flex: 1;
+  order: 2;
+  min-width: 1.5rem;
+  border-bottom: 1px dotted color-mix(in srgb, var(--muted) 45%, transparent);
+  transform: translateY(-0.28em);
+}
+
 .log-state {
+  flex: none;
+  order: 3;
   color: var(--muted);
-  font-size: 0.72rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.03em;
 }
 
 .log-item.is-done .log-mark {
   color: var(--accent);
 }
 
-.log-item.is-active .log-mark,
-.log-item.is-active .log-state {
+.log-item.is-active .log-mark {
   color: var(--accent);
+}
+
+.log-item.is-active .log-label {
+  color: var(--text);
   font-weight: 600;
 }
 
+.log-item.is-active .log-state {
+  padding: 0.14rem 0.55rem;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  color: var(--accent);
+  font-weight: 600;
+  transform: translateY(0.05em);
+}
+
+.log-item.is-queued .log-mark,
 .log-item.is-queued .log-label,
 .log-item.is-queued .log-state {
-  opacity: 0.65;
+  opacity: 0.55;
 }
 
 @media (prefers-reduced-motion: no-preference) {
+  .deploy-log-title::after,
   .log-item.is-active .log-mark {
-    animation: log-pulse 2.2s ease-in-out infinite;
+    animation: log-pulse 2.4s ease-in-out infinite;
   }
 
   @keyframes log-pulse {
     0%, 100% { opacity: 1; }
-    50% { opacity: 0.35; }
+    50% { opacity: 0.4; }
   }
 }
 
@@ -381,6 +432,29 @@ h1 {
 
   .lede {
     max-width: 31rem;
+  }
+
+  .deploy-log {
+    max-width: none;
+    font-size: 0.74rem;
+  }
+
+  .deploy-log-title {
+    padding: 0.55rem 0.9rem;
+  }
+
+  .log-item {
+    padding: 0.34rem 0.9rem;
+    gap: 0.5rem;
+  }
+
+  .log-state {
+    font-size: 0.66rem;
+  }
+
+  .contact-row {
+    gap: 1.25rem;
+    row-gap: 1rem;
   }
 
   .site-footer {

--- a/static/css/construction.css
+++ b/static/css/construction.css
@@ -15,8 +15,8 @@
   --accent: #276148;
   --accent-ink: #f3f7f3;
   --focus: #276148;
-  --font-sans: "Avenir Next", Avenir, "Helvetica Neue", Helvetica, Arial, sans-serif;
-  --font-mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  --font-sans: "DM Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-mono: "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -171,10 +171,118 @@ h1 {
   line-height: 1.6;
 }
 
+.deploy-log {
+  max-width: 26rem;
+  margin-top: clamp(1.75rem, 3.5vw, 2.75rem);
+  border: 1px solid var(--line);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+}
+
+.deploy-log-title {
+  margin: 0;
+  padding: 0.55rem 1rem;
+  border-bottom: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.deploy-log-list {
+  margin: 0;
+  padding: 0.65rem 0;
+  list-style: none;
+}
+
+.log-item {
+  padding: 0.32rem 1rem;
+  display: grid;
+  grid-template-columns: 1.25rem 1fr auto;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.log-mark {
+  color: var(--muted);
+}
+
+.log-state {
+  color: var(--muted);
+  font-size: 0.72rem;
+}
+
+.log-item.is-done .log-mark {
+  color: var(--accent);
+}
+
+.log-item.is-active .log-mark,
+.log-item.is-active .log-state {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.log-item.is-queued .log-label,
+.log-item.is-queued .log-state {
+  opacity: 0.65;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .log-item.is-active .log-mark {
+    animation: log-pulse 2.2s ease-in-out infinite;
+  }
+
+  @keyframes log-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.35; }
+  }
+}
+
+.contact-row {
+  margin-top: clamp(1.75rem, 3vw, 2.5rem);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1.75rem;
+}
+
+.social-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--text);
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-decoration: none;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 0.15rem;
+  transition: border-color 180ms ease, color 180ms ease;
+}
+
+.social-link span {
+  color: var(--muted);
+  font-size: 0.8rem;
+  transition: transform 180ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.social-link:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.social-link:hover span {
+  transform: translate(0.12rem, -0.12rem);
+}
+
+.social-link:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 4px;
+}
+
 .contact-link {
   width: fit-content;
   min-height: 3.25rem;
-  margin-top: clamp(1.75rem, 3vw, 2.5rem);
   padding: 0 1.25rem;
   display: inline-flex;
   align-items: center;
@@ -227,6 +335,7 @@ h1 {
   .construction-copy > :nth-child(2) { animation-delay: 70ms; }
   .construction-copy > :nth-child(3) { animation-delay: 140ms; }
   .construction-copy > :nth-child(4) { animation-delay: 210ms; }
+  .construction-copy > :nth-child(5) { animation-delay: 280ms; }
 
   @keyframes enter-copy {
     from { opacity: 0; transform: translateY(1.25rem); }

--- a/templates/construction.html
+++ b/templates/construction.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{{ config.brand_name }} | Site in transition</title>
-  <meta name="description" content="{{ config.brand_name }} is changing direction. A new, more focused site is on the way." />
+  <meta name="description" content="toucan.ee is being rebuilt around DevOps and platform engineering. A new, more focused site is on the way." />
 
   <link rel="canonical" href="{{ canonical_url }}" />
   <meta name="robots" content="noindex, nofollow" />
@@ -15,6 +15,9 @@
   <meta property="og:description" content="Toucan is changing direction. A new, more focused site is on the way." />
   <meta property="og:url" content="{{ canonical_url }}" />
 
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,300..1000&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="{{ url_for('static', filename='css/construction.css', v=config.asset_version) }}" />
 </head>
 <body>
@@ -28,7 +31,7 @@
 
     <main class="construction-main">
       <section class="construction-copy" aria-labelledby="construction-title">
-        <p class="eyebrow">A new direction</p>
+        <p class="eyebrow">Rebuild in progress</p>
         <h1 id="construction-title">
           <span class="headline-line headline-line-first">
             <span class="headline-light">Changing</span>
@@ -40,12 +43,51 @@
           </span>
         </h1>
         <p class="lede">
-          I&rsquo;m rebuilding Toucan around a new idea. More soon.
+          I&rsquo;m {{ config.name }} &mdash; DevOps and platform engineering.
+          I&rsquo;m rebuilding toucan.ee as a live piece of infrastructure;
+          the full site lands soon.
         </p>
-        <a class="contact-link" href="mailto:{{ config.email }}">
-          Start a conversation
-          <span aria-hidden="true">&#8599;</span>
-        </a>
+
+        <div class="deploy-log" aria-labelledby="deploy-log-title">
+          <p class="deploy-log-title" id="deploy-log-title">deploy log</p>
+          <ul class="deploy-log-list">
+            <li class="log-item is-done">
+              <span class="log-mark" aria-hidden="true">&#10003;</span>
+              <span class="log-label">design system</span>
+              <span class="log-state">shipped</span>
+            </li>
+            <li class="log-item is-done">
+              <span class="log-mark" aria-hidden="true">&#10003;</span>
+              <span class="log-label">static build pipeline</span>
+              <span class="log-state">shipped</span>
+            </li>
+            <li class="log-item is-active">
+              <span class="log-mark" aria-hidden="true">&#9656;</span>
+              <span class="log-label">terraform + aws</span>
+              <span class="log-state">in progress</span>
+            </li>
+            <li class="log-item is-queued">
+              <span class="log-mark" aria-hidden="true">&#9675;</span>
+              <span class="log-label">cv, devops edition</span>
+              <span class="log-state">queued</span>
+            </li>
+          </ul>
+        </div>
+
+        <div class="contact-row">
+          <a class="contact-link" href="mailto:{{ config.email }}">
+            Email me
+            <span aria-hidden="true">&#8599;</span>
+          </a>
+          <a class="social-link" href="{{ config.linkedin_url }}" target="_blank" rel="noopener">
+            LinkedIn <span aria-hidden="true">&#8599;</span>
+          </a>
+          {% if config.github_url %}
+          <a class="social-link" href="{{ config.github_url }}" target="_blank" rel="noopener">
+            GitHub <span aria-hidden="true">&#8599;</span>
+          </a>
+          {% endif %}
+        </div>
       </section>
     </main>
 


### PR DESCRIPTION
## Summary
Implements the status-board direction from #301: the transition page now says who owns the site, what's being built, and how to get in touch — instead of two abstract lines.

## Changes
- **Fonts**: DM Sans + JetBrains Mono (was Avenir Next), matching the shipped design system
- **Lede**: names Sreyeesh Garimella, positions DevOps/platform engineering
- **Deploy log**: mono status block — design system ✓, static pipeline ✓, terraform + aws ▸ in progress, cv ○ queued
- **Contact row**: Email button + LinkedIn/GitHub links (`rel="noopener"`, GitHub gated on `config.github_url`, now defaulted to the real profile)
- Entrance animation stagger extended to the new blocks; the active log marker pulses, gated behind `prefers-reduced-motion`

## Testing
- Full suite passes in Docker (27 passed) — `test_home_page_is_construction_placeholder` constraints hold: one mailto, no `<img>`, "Site in transition" intact
- Verified rendered output on the live dev container

Closes #301