### PR TITLE
feat(metrics): bake real repo metrics into the page at build time

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@ __pycache__
 *.pyc
 *.pyo
 .pytest_cache
+instance/
 .env
 .env.dev
 .venv

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,7 +9,12 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     curl \
+    git \
     && rm -rf /var/lib/apt/lists/*
+
+# The repo is volume-mounted and owned by the host user; the container
+# runs as root, so git's dubious-ownership guard would refuse it.
+RUN git config --global --add safe.directory /app
 
 # Copy requirements and install Python dependencies
 COPY requirements.txt .

--- a/app.py
+++ b/app.py
@@ -15,6 +15,11 @@ app = Flask(__name__)
 app.config['TEMPLATES_AUTO_RELOAD'] = True
 
 from blog import find_post, load_posts, normalize_media_path  # noqa: E402
+from metrics import collect_metrics  # noqa: E402
+
+# Captured once at startup / freeze time — the static build bakes these
+# values into the HTML, so they are "as of last deploy" by design.
+BUILD_METRICS = collect_metrics()
 
 
 def _icon(name, size=16, label=None):
@@ -433,6 +438,7 @@ def _csv_safe(value: str) -> str:
 def home():
     return render_template(
         'construction.html',
+        metrics=BUILD_METRICS,
         **build_page_context(page_slug='home'),
     )
 

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,77 @@
+"""Build-time repository metrics for the construction dashboard.
+
+The public site is frozen to static HTML, so these values are captured
+once — when the page is rendered/frozen — and baked into the output.
+That is deliberate: a static site's "telemetry" is whatever was true at
+build time.
+
+Every value degrades to None when git or the .git directory is missing
+(the production Docker image has neither); the dashboard renders those
+as "n/a" rather than inventing numbers.
+"""
+
+import subprocess
+from datetime import datetime, timedelta, timezone
+
+SPARKLINE_WEEKS = 12
+_GIT_TIMEOUT_SECONDS = 10
+
+
+def _git(args, cwd=None):
+    """Run a git command; return stripped stdout, or None on any failure."""
+    try:
+        result = subprocess.run(
+            ['git', *args],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+            cwd=cwd,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        # OSError: git binary missing. CalledProcessError: not a repo /
+        # bad ref. TimeoutExpired: pathological repo. All mean "no data".
+        return None
+    return result.stdout.strip()
+
+
+def _weekly_commit_counts(now, repo_dir=None, weeks=SPARKLINE_WEEKS):
+    """Commit counts per week, oldest first, over the last `weeks` weeks."""
+    since = now - timedelta(weeks=weeks)
+    raw = _git(
+        ['log', f'--since={since.isoformat()}', '--format=%ct'],
+        cwd=repo_dir,
+    )
+    if raw is None:
+        return None
+
+    counts = [0] * weeks
+    for line in raw.splitlines():
+        commit_time = datetime.fromtimestamp(int(line), tz=timezone.utc)
+        weeks_ago = (now - commit_time) // timedelta(weeks=1)
+        if 0 <= weeks_ago < weeks:
+            counts[weeks - 1 - weeks_ago] += 1
+    return counts
+
+
+def collect_metrics(repo_dir=None, now=None):
+    """Assemble the dashboard metrics dict.
+
+    `repo_dir` and `now` exist so tests can inject a fixed repo path and
+    a frozen clock instead of depending on the real environment.
+    """
+    now = now or datetime.now(timezone.utc)
+
+    total = _git(['rev-list', '--count', 'HEAD'], cwd=repo_dir)
+    last_commit_iso = _git(['log', '-1', '--format=%cI'], cwd=repo_dir)
+
+    return {
+        'available': total is not None,
+        'total_commits': int(total) if total is not None else None,
+        'last_commit': (
+            datetime.fromisoformat(last_commit_iso)
+            if last_commit_iso else None
+        ),
+        'weekly_commits': _weekly_commit_counts(now, repo_dir=repo_dir),
+        'generated_at': now,
+    }

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,94 @@
+"""Tests for the build-time metrics module.
+
+subprocess is never invoked for real: _git is patched with fakes so the
+tests are deterministic and run in containers without git.
+"""
+
+import subprocess
+from datetime import datetime, timedelta, timezone
+
+import metrics
+
+NOW = datetime(2026, 7, 2, 12, 0, tzinfo=timezone.utc)
+
+
+def _epoch(dt):
+    return str(int(dt.timestamp()))
+
+
+def fake_git_factory(responses):
+    """Build a _git replacement returning canned output per subcommand."""
+    def fake_git(args, cwd=None):
+        return responses.get(args[0])
+    return fake_git
+
+
+def test_collect_metrics_parses_git_output(monkeypatch):
+    log_lines = '\n'.join([
+        _epoch(NOW - timedelta(days=1)),       # this week
+        _epoch(NOW - timedelta(days=2)),       # this week
+        _epoch(NOW - timedelta(weeks=3)),      # three weeks ago
+    ])
+
+    def fake_git(args, cwd=None):
+        if args[0] == 'rev-list':
+            return '321'
+        if args == ['log', '-1', '--format=%cI']:
+            return '2026-07-01T09:30:00+03:00'
+        if args[0] == 'log':
+            return log_lines
+        raise AssertionError(f'unexpected git args: {args}')
+
+    monkeypatch.setattr(metrics, '_git', fake_git)
+    result = metrics.collect_metrics(now=NOW)
+
+    assert result['available'] is True
+    assert result['total_commits'] == 321
+    assert result['last_commit'] == datetime.fromisoformat(
+        '2026-07-01T09:30:00+03:00'
+    )
+    assert result['generated_at'] == NOW
+
+    weekly = result['weekly_commits']
+    assert len(weekly) == metrics.SPARKLINE_WEEKS
+    assert weekly[-1] == 2          # newest bucket: the two recent commits
+    assert weekly[-4] == 1          # the commit from three weeks ago
+    assert sum(weekly) == 3
+
+
+def test_collect_metrics_without_git_degrades_to_none(monkeypatch):
+    monkeypatch.setattr(metrics, '_git', lambda args, cwd=None: None)
+    result = metrics.collect_metrics(now=NOW)
+
+    assert result == {
+        'available': False,
+        'total_commits': None,
+        'last_commit': None,
+        'weekly_commits': None,
+        'generated_at': NOW,
+    }
+
+
+def test_weekly_counts_ignore_commits_outside_window(monkeypatch):
+    stale = _epoch(NOW - timedelta(weeks=metrics.SPARKLINE_WEEKS + 1))
+    monkeypatch.setattr(
+        metrics, '_git', fake_git_factory({'log': stale})
+    )
+    counts = metrics._weekly_commit_counts(NOW)
+    assert sum(counts) == 0
+
+
+def test_git_helper_swallows_missing_binary(monkeypatch):
+    def raise_missing(*args, **kwargs):
+        raise FileNotFoundError('git not installed')
+
+    monkeypatch.setattr(subprocess, 'run', raise_missing)
+    assert metrics._git(['rev-list', '--count', 'HEAD']) is None
+
+
+def test_git_helper_swallows_command_failure(monkeypatch):
+    def raise_called_process_error(*args, **kwargs):
+        raise subprocess.CalledProcessError(128, 'git')
+
+    monkeypatch.setattr(subprocess, 'run', raise_called_process_error)
+    assert metrics._git(['log', '-1']) is None


### PR DESCRIPTION
## Summary
Implements #305 — the data layer for the Sprint 5 Grafana-style dashboard (#304). A new `metrics.py` module snapshots real repository data at startup/freeze time; the static build bakes the values into the HTML, which is the honest way for a static site to do telemetry.

## What it collects
- Total commits (`git rev-list --count HEAD`) — currently **439**
- Last-commit timestamp (`git log -1 --format=%cI`)
- 12-week commit histogram for the sparkline (`git log --since … --format=%ct`, bucketed per week)
- Build timestamp

## Design
- **Graceful degradation**: any git failure (missing binary, no `.git`, timeout) → `None` values with `available: False`; the dashboard will render "n/a" — never invented numbers. The prod image (no git, no `.git`) exercises exactly this path.
- **Testable**: `collect_metrics(repo_dir=…, now=…)` takes an injectable clock and repo path; tests patch `_git` with canned output and never spawn a process.
- Snapshot captured once at import (`BUILD_METRICS`) and passed to the construction route; the template renders it in #304.

## Infra fixes found along the way
- `instance/` (root-owned runtime data) broke every docker build's context scan → added to `.dockerignore`
- Dev image lacked `git`, and the volume-mounted repo tripped git's dubious-ownership guard (CVE-2022-24765) → install git + `safe.directory /app` in `Dockerfile.dev`

## Testing
- 32 passed (5 new in `tests/test_metrics.py`: parsing, no-git degradation, window bounds, missing-binary and failed-command handling)
- flake8 clean
- Verified real values render inside the rebuilt dev container

Closes #305