### PR TITLE
feat(construction): Grafana-style dashboard takeover

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -27,6 +27,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Full history: the construction dashboard bakes real commit
+          # counts into the page; a shallow clone would report 1 commit.
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/app.py
+++ b/app.py
@@ -435,11 +435,35 @@ def _csv_safe(value: str) -> str:
     return value
 
 
+# Rebuild-board content for the construction dashboard. The workstream
+# stat panel derives shipped/total from this list — update it here only.
+CONSTRUCTION_PAGE = {
+    'workstreams': [
+        {'label': 'design system', 'state': 'shipped'},
+        {'label': 'static build pipeline', 'state': 'shipped'},
+        {'label': 'terraform + aws', 'state': 'in progress'},
+        {'label': 'cv, devops edition', 'state': 'queued'},
+    ],
+    'deploy_target': [
+        {'label': 'compute', 'value': 'AWS EC2, free tier'},
+        {'label': 'provisioning', 'value': 'Terraform'},
+        {'label': 'serving', 'value': 'gunicorn + nginx, Docker'},
+        {'label': 'current host', 'value': 'GitHub Pages, static'},
+    ],
+}
+
+
 @app.route('/')
 def home():
+    workstreams = CONSTRUCTION_PAGE['workstreams']
     return render_template(
         'construction.html',
         metrics=BUILD_METRICS,
+        workstreams=workstreams,
+        shipped_count=sum(
+            1 for item in workstreams if item['state'] == 'shipped'
+        ),
+        deploy_target=CONSTRUCTION_PAGE['deploy_target'],
         **build_page_context(page_slug='home'),
     )
 

--- a/app.py
+++ b/app.py
@@ -15,11 +15,12 @@ app = Flask(__name__)
 app.config['TEMPLATES_AUTO_RELOAD'] = True
 
 from blog import find_post, load_posts, normalize_media_path  # noqa: E402
-from metrics import collect_metrics  # noqa: E402
+from metrics import bar_heights, collect_metrics  # noqa: E402
 
 # Captured once at startup / freeze time — the static build bakes these
 # values into the HTML, so they are "as of last deploy" by design.
 BUILD_METRICS = collect_metrics()
+BUILD_METRICS['weekly_bars'] = bar_heights(BUILD_METRICS['weekly_commits'])
 
 
 def _icon(name, size=16, label=None):

--- a/metrics.py
+++ b/metrics.py
@@ -54,6 +54,21 @@ def _weekly_commit_counts(now, repo_dir=None, weeks=SPARKLINE_WEEKS):
     return counts
 
 
+def bar_heights(counts, floor=6):
+    """Scale commit counts to 0-100 bar heights for the CSS chart.
+
+    `floor` keeps zero-commit weeks faintly visible so the chart reads
+    as "quiet week", not "missing data".
+    """
+    if not counts:
+        return None
+    peak = max(counts) or 1
+    return [
+        max(round(count / peak * 100), floor) if count else floor
+        for count in counts
+    ]
+
+
 def collect_metrics(repo_dir=None, now=None):
     """Assemble the dashboard metrics dict.
 

--- a/static/css/construction.css
+++ b/static/css/construction.css
@@ -1,4 +1,5 @@
-/* Standalone transition page. Kept independent from the legacy site styles. */
+/* Standalone transition page: dark dashboard takeover (#304).
+   Kept independent from the legacy site styles. */
 
 *,
 *::before,
@@ -7,33 +8,24 @@
 }
 
 :root {
-  color-scheme: light dark;
-  --surface: #eef0ec;
-  --text: #18201b;
-  --muted: #59635c;
-  --line: rgba(24, 32, 27, 0.17);
-  --accent: #276148;
-  --accent-ink: #f3f7f3;
-  --focus: #276148;
+  color-scheme: dark;
+  --bg: #0e1310;
+  --panel: #141a16;
+  --panel-raised: #17201b;
+  --line: #26302a;
+  --text: #e6ebe7;
+  --muted: #8fa096;
+  --accent: #5fd39a;
+  --accent-dim: color-mix(in srgb, var(--accent) 16%, transparent);
+  --accent-ink: #0d1f16;
+  --focus: #8ae4b8;
   --font-sans: "DM Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  --font-mono: "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --surface: #121714;
-    --text: #e8ece8;
-    --muted: #a5afa7;
-    --line: rgba(232, 236, 232, 0.17);
-    --accent: #99c7aa;
-    --accent-ink: #132019;
-    --focus: #b5dcc1;
-  }
+  --font-mono: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
 }
 
 html {
   min-width: 320px;
-  background: var(--surface);
+  background: var(--bg);
   -webkit-text-size-adjust: 100%;
 }
 
@@ -41,7 +33,7 @@ body {
   min-width: 320px;
   min-height: 100dvh;
   margin: 0;
-  background: var(--surface);
+  background: var(--bg);
   color: var(--text);
   font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
@@ -52,36 +44,27 @@ a {
   color: inherit;
 }
 
-.construction-shell {
-  width: min(100%, 96rem);
+.dash {
+  width: min(100%, 78rem);
   min-height: 100dvh;
   margin: 0 auto;
-  padding: 0 clamp(1.25rem, 4vw, 4.5rem);
+  padding: 0 clamp(1rem, 3vw, 2.5rem);
   display: grid;
   grid-template-rows: auto 1fr auto;
 }
 
-.site-header,
-.site-footer {
-  min-height: 4.5rem;
+/* ── Top bar ─────────────────────────────── */
+
+.dash-topbar {
+  min-height: 3.75rem;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 1.5rem;
-  border-color: var(--line);
-  font-family: var(--font-mono);
-  font-size: 0.72rem;
-  letter-spacing: 0.06em;
-}
-
-.site-header {
+  gap: 1.25rem;
   border-bottom: 1px solid var(--line);
 }
 
 .wordmark {
-  padding: 0.5rem 0;
   color: var(--text);
-  font-family: var(--font-sans);
   font-size: 1rem;
   font-weight: 750;
   letter-spacing: -0.025em;
@@ -92,264 +75,327 @@ a {
   color: var(--accent);
 }
 
-.site-state {
+.dash-state,
+.dash-updated {
   margin: 0;
   color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
-.construction-main {
+.dash-state {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.dash-updated {
+  margin-left: auto;
+  text-transform: none;
+  letter-spacing: 0.02em;
+}
+
+.live-dot {
+  width: 0.45rem;
+  height: 0.45rem;
+  flex: none;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-dim);
+}
+
+/* ── Panel grid ──────────────────────────── */
+
+.dash-grid {
+  padding: clamp(1rem, 2.5vw, 1.75rem) 0;
   display: grid;
   grid-template-columns: repeat(12, minmax(0, 1fr));
-  align-items: center;
-  padding: clamp(2.5rem, 7vh, 6.5rem) 0;
+  gap: clamp(0.65rem, 1.5vw, 1rem);
+  align-content: start;
 }
 
-.construction-copy {
-  grid-column: 1 / -1;
-  max-width: none;
-  position: relative;
-  z-index: 1;
-}
-
-.eyebrow {
-  margin: 0 0 1.5rem;
-  color: var(--accent);
-  font-family: var(--font-mono);
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-h1 {
-  max-width: none;
-  margin: 0;
-  font-size: clamp(3.25rem, 7.2vw, 6.8rem);
-  font-weight: 560;
-  font-kerning: normal;
-  letter-spacing: -0.065em;
-  line-height: 0.98;
-  text-wrap: balance;
-}
-
-.headline-line {
-  width: fit-content;
-  display: flex;
-  align-items: baseline;
-  gap: 0.16em;
-  white-space: nowrap;
-}
-
-.headline-line-second {
-  margin-left: clamp(2.5rem, 8vw, 8rem);
-}
-
-.headline-line em {
-  padding-bottom: 0.08em;
-  display: inline-block;
-  font-style: italic;
-  font-weight: 650;
-  line-height: 1.08;
-}
-
-.headline-line strong {
-  color: var(--accent);
-  font-weight: 780;
-}
-
-.headline-light {
-  color: var(--text);
-  font-weight: 380;
-}
-
-.lede {
-  max-width: 35rem;
-  margin: clamp(1.5rem, 3vw, 2.25rem) 0 0;
-  color: var(--muted);
-  font-size: clamp(1rem, 1.35vw, 1.2rem);
-  line-height: 1.6;
-}
-
-.deploy-log {
-  max-width: 27rem;
-  margin-top: clamp(1.75rem, 3.5vw, 2.75rem);
+.panel {
+  padding: 1.1rem 1.25rem 1.2rem;
   border: 1px solid var(--line);
-  background: color-mix(in srgb, var(--text) 3.5%, transparent);
-  font-family: var(--font-mono);
-  font-size: 0.78rem;
+  border-radius: 3px;
+  background: var(--panel);
 }
 
-.deploy-log-title {
-  margin: 0;
-  padding: 0.6rem 1.1rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  border-bottom: 1px solid var(--line);
+.panel-title {
+  margin: 0 0 0.85rem;
   color: var(--muted);
+  font-family: var(--font-mono);
   font-size: 0.66rem;
   font-weight: 600;
   letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
-/* live indicator dot in the panel header */
-.deploy-log-title::after {
-  content: "";
-  width: 0.45rem;
-  height: 0.45rem;
-  flex: none;
-  border-radius: 50%;
-  background: var(--accent);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent);
-}
-
-.deploy-log-list {
+.panel-na {
   margin: 0;
-  padding: 0.75rem 0;
-  list-style: none;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
 }
 
-.log-item {
-  padding: 0.38rem 1.1rem;
+/* ── Intro panel ─────────────────────────── */
+
+.panel-intro {
+  grid-column: span 12;
+  background: var(--panel-raised);
+}
+
+.panel-intro h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3.4vw, 2.6rem);
+  font-weight: 560;
+  letter-spacing: -0.04em;
+  line-height: 1.12;
+  text-wrap: balance;
+}
+
+.headline-light {
+  font-weight: 340;
+}
+
+.panel-intro strong {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.lede {
+  max-width: 46rem;
+  margin: 0.85rem 0 0;
+  color: var(--muted);
+  font-size: clamp(0.95rem, 1.2vw, 1.05rem);
+  line-height: 1.6;
+}
+
+/* ── Stat panels ─────────────────────────── */
+
+.panel-stat {
+  grid-column: span 4;
+}
+
+.stat-value {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: clamp(1.9rem, 3.4vw, 2.6rem);
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  line-height: 1.05;
+}
+
+.stat-value--date {
+  font-size: clamp(1.5rem, 2.6vw, 2rem);
+}
+
+.stat-of {
+  color: var(--muted);
+  font-size: 0.55em;
+  font-weight: 500;
+}
+
+.stat-sub {
+  margin: 0.45rem 0 0;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.03em;
+}
+
+/* ── Activity chart ──────────────────────── */
+
+.panel-activity {
+  grid-column: span 8;
+  display: flex;
+  flex-direction: column;
+}
+
+.bar-chart {
+  height: 7.5rem;
+  flex: 1;
+  display: flex;
+  align-items: flex-end;
+  gap: clamp(0.3rem, 0.8vw, 0.55rem);
+  padding-top: 0.25rem;
+}
+
+.bar {
+  flex: 1;
+  height: var(--h);
+  min-height: 3px;
+  border-radius: 2px 2px 0 0;
+  background: color-mix(in srgb, var(--accent) 38%, transparent);
+}
+
+.bar--current {
+  background: var(--accent);
+}
+
+.chart-legend {
+  margin: 0.8rem 0 0;
+  display: flex;
+  justify-content: space-between;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.03em;
+}
+
+/* ── Status panel ────────────────────────── */
+
+.panel-status {
+  grid-column: span 4;
+}
+
+.status-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+}
+
+.status-item {
+  padding: 0.42rem 0;
   display: flex;
   align-items: baseline;
   gap: 0.6rem;
 }
 
-.log-mark {
+.status-item + .status-item {
+  border-top: 1px solid color-mix(in srgb, var(--line) 55%, transparent);
+}
+
+.status-mark {
   flex: none;
-  order: 0;
   width: 1.1rem;
   color: var(--muted);
 }
 
-.log-label {
+.status-label {
   flex: none;
-  order: 1;
-  letter-spacing: 0.01em;
 }
 
-/* dotted leader connecting label to state */
-.log-item::after {
+.status-item::after {
   content: "";
   flex: 1;
-  order: 2;
-  min-width: 1.5rem;
-  border-bottom: 1px dotted color-mix(in srgb, var(--muted) 45%, transparent);
+  min-width: 1rem;
+  border-bottom: 1px dotted color-mix(in srgb, var(--muted) 40%, transparent);
   transform: translateY(-0.28em);
 }
 
-.log-state {
+.status-state {
   flex: none;
-  order: 3;
+  order: 4;
   color: var(--muted);
-  font-size: 0.7rem;
+  font-size: 0.68rem;
   letter-spacing: 0.03em;
 }
 
-.log-item.is-done .log-mark {
+.status-item.is-done .status-mark {
   color: var(--accent);
 }
 
-.log-item.is-active .log-mark {
+.status-item.is-active .status-mark {
   color: var(--accent);
 }
 
-.log-item.is-active .log-label {
-  color: var(--text);
+.status-item.is-active .status-label {
   font-weight: 600;
 }
 
-.log-item.is-active .log-state {
-  padding: 0.14rem 0.55rem;
+.status-item.is-active .status-state {
+  padding: 0.12rem 0.5rem;
   border-radius: 2px;
-  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  background: var(--accent-dim);
   color: var(--accent);
   font-weight: 600;
-  transform: translateY(0.05em);
 }
 
-.log-item.is-queued .log-mark,
-.log-item.is-queued .log-label,
-.log-item.is-queued .log-state {
+.status-item.is-queued > * {
   opacity: 0.55;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  .deploy-log-title::after,
-  .log-item.is-active .log-mark {
-    animation: log-pulse 2.4s ease-in-out infinite;
-  }
+/* ── Target panel ────────────────────────── */
 
-  @keyframes log-pulse {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.4; }
-  }
+.panel-target {
+  grid-column: span 7;
+}
+
+.target-list {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+}
+
+.target-row {
+  padding: 0.42rem 0;
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.target-row + .target-row {
+  border-top: 1px solid color-mix(in srgb, var(--line) 55%, transparent);
+}
+
+.target-row dt {
+  flex: none;
+  width: 8.5rem;
+  color: var(--muted);
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.target-row dd {
+  margin: 0;
+}
+
+/* ── Contact panel ───────────────────────── */
+
+.panel-contact {
+  grid-column: span 5;
+}
+
+.contact-copy {
+  margin: 0 0 1rem;
+  color: var(--muted);
+  font-size: 0.92rem;
+  line-height: 1.55;
 }
 
 .contact-row {
-  margin-top: clamp(1.75rem, 3vw, 2.5rem);
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 1.75rem;
-}
-
-.social-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  color: var(--text);
-  font-size: 0.88rem;
-  font-weight: 600;
-  text-decoration: none;
-  border-bottom: 1px solid var(--line);
-  padding-bottom: 0.15rem;
-  transition: border-color 180ms ease, color 180ms ease;
-}
-
-.social-link span {
-  color: var(--muted);
-  font-size: 0.8rem;
-  transition: transform 180ms cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.social-link:hover {
-  color: var(--accent);
-  border-color: var(--accent);
-}
-
-.social-link:hover span {
-  transform: translate(0.12rem, -0.12rem);
-}
-
-.social-link:focus-visible {
-  outline: 2px solid var(--focus);
-  outline-offset: 4px;
+  gap: 1.25rem;
+  row-gap: 0.9rem;
 }
 
 .contact-link {
-  width: fit-content;
-  min-height: 3.25rem;
-  padding: 0 1.25rem;
+  min-height: 2.75rem;
+  padding: 0 1.1rem;
   display: inline-flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.75rem;
+  border-radius: 2px;
   background: var(--accent);
   color: var(--accent-ink);
-  font-size: 0.88rem;
+  font-size: 0.85rem;
   font-weight: 700;
   line-height: 1;
   text-decoration: none;
   white-space: nowrap;
-  transition: transform 180ms cubic-bezier(0.16, 1, 0.3, 1), opacity 180ms ease;
+  transition: opacity 180ms ease, transform 180ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .contact-link span {
-  font-size: 1rem;
+  font-size: 0.95rem;
   transition: transform 180ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
@@ -365,118 +411,148 @@ h1 {
   transform: translateY(1px);
 }
 
-.wordmark:focus-visible,
-.contact-link:focus-visible {
-  outline: 2px solid var(--focus);
-  outline-offset: 4px;
+.social-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding-bottom: 0.15rem;
+  border-bottom: 1px solid var(--line);
+  color: var(--text);
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: border-color 180ms ease, color 180ms ease;
 }
 
-.site-footer {
-  min-height: 4rem;
+.social-link span {
+  color: var(--muted);
+  font-size: 0.78rem;
+  transition: transform 180ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.social-link:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.social-link:hover span {
+  transform: translate(0.12rem, -0.12rem);
+}
+
+.wordmark:focus-visible,
+.contact-link:focus-visible,
+.social-link:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 3px;
+}
+
+/* ── Footer ──────────────────────────────── */
+
+.dash-footer {
+  min-height: 3.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
   border-top: 1px solid var(--line);
   color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
 }
+
+/* ── Motion ──────────────────────────────── */
 
 @media (prefers-reduced-motion: no-preference) {
-  .construction-copy > * {
-    opacity: 0;
-    animation: enter-copy 700ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  .live-dot {
+    animation: live-pulse 2.4s ease-in-out infinite;
   }
 
-  .construction-copy > :nth-child(2) { animation-delay: 70ms; }
-  .construction-copy > :nth-child(3) { animation-delay: 140ms; }
-  .construction-copy > :nth-child(4) { animation-delay: 210ms; }
-  .construction-copy > :nth-child(5) { animation-delay: 280ms; }
+  .status-item.is-active .status-mark {
+    animation: live-pulse 2.4s ease-in-out infinite;
+  }
 
-  @keyframes enter-copy {
-    from { opacity: 0; transform: translateY(1.25rem); }
+  .panel {
+    opacity: 0;
+    animation: panel-enter 600ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  }
+
+  .dash-grid > :nth-child(2) { animation-delay: 60ms; }
+  .dash-grid > :nth-child(3) { animation-delay: 110ms; }
+  .dash-grid > :nth-child(4) { animation-delay: 160ms; }
+  .dash-grid > :nth-child(5) { animation-delay: 210ms; }
+  .dash-grid > :nth-child(6) { animation-delay: 260ms; }
+  .dash-grid > :nth-child(7) { animation-delay: 310ms; }
+  .dash-grid > :nth-child(8) { animation-delay: 360ms; }
+
+  .bar {
+    transform-origin: bottom;
+    animation: bar-grow 700ms cubic-bezier(0.16, 1, 0.3, 1) backwards;
+    animation-delay: 450ms;
+  }
+
+  @keyframes live-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.4; }
+  }
+
+  @keyframes panel-enter {
+    from { opacity: 0; transform: translateY(0.75rem); }
     to { opacity: 1; transform: translateY(0); }
   }
+
+  @keyframes bar-grow {
+    from { transform: scaleY(0); }
+    to { transform: scaleY(1); }
+  }
 }
 
-@media (max-width: 767px) {
-  .construction-shell {
-    padding: 0 1.25rem;
+/* ── Responsive ──────────────────────────── */
+
+@media (max-width: 900px) {
+  .panel-activity {
+    grid-column: span 12;
   }
 
-  .site-header {
-    min-height: 4rem;
+  .panel-status,
+  .panel-stat {
+    grid-column: span 6;
   }
 
-  .construction-main {
-    grid-template-columns: 1fr;
-    align-items: start;
-    padding: 3.25rem 0 2rem;
+  .panel-status {
+    grid-column: span 12;
   }
 
-  .construction-copy {
-    grid-column: 1;
-    width: 100%;
-    max-width: none;
+  .panel-target,
+  .panel-contact {
+    grid-column: span 12;
+  }
+}
+
+@media (max-width: 620px) {
+  .dash-topbar {
+    flex-wrap: wrap;
+    gap: 0.35rem 1.25rem;
+    padding: 0.75rem 0;
   }
 
-  h1 {
-    max-width: none;
-    font-size: clamp(2.75rem, 13.5vw, 4.25rem);
-  }
-
-  .headline-line {
-    width: auto;
-    display: block;
-    white-space: normal;
-  }
-
-  .headline-line-second {
+  .dash-updated {
     margin-left: 0;
+    width: 100%;
   }
 
-  .lede {
-    max-width: 31rem;
+  .panel-stat {
+    grid-column: span 12;
   }
 
-  .deploy-log {
-    max-width: none;
-    font-size: 0.74rem;
+  .bar-chart {
+    height: 5.5rem;
   }
 
-  .deploy-log-title {
-    padding: 0.55rem 0.9rem;
-  }
-
-  .log-item {
-    padding: 0.34rem 0.9rem;
-    gap: 0.5rem;
-  }
-
-  .log-state {
-    font-size: 0.66rem;
-  }
-
-  .contact-row {
-    gap: 1.25rem;
-    row-gap: 1rem;
-  }
-
-  .site-footer {
-    padding: 1rem 0;
-    align-items: flex-start;
+  .dash-footer {
+    padding: 0.85rem 0;
     flex-direction: column;
-    justify-content: center;
-    gap: 0.35rem;
-  }
-}
-
-@media (max-width: 420px) {
-  .site-state {
-    font-size: 0.65rem;
-    letter-spacing: 0.04em;
-  }
-
-  .construction-main {
-    padding-top: 2.5rem;
-  }
-
-  .eyebrow {
-    margin-bottom: 1.1rem;
+    align-items: flex-start;
+    gap: 0.3rem;
   }
 }

--- a/static/css/construction.css
+++ b/static/css/construction.css
@@ -514,7 +514,6 @@ a {
     grid-column: span 12;
   }
 
-  .panel-status,
   .panel-stat {
     grid-column: span 6;
   }

--- a/templates/construction.html
+++ b/templates/construction.html
@@ -70,7 +70,7 @@
 
       <section class="panel panel-stat" aria-label="Rebuild progress">
         <p class="panel-title">rebuild workstreams</p>
-        <p class="stat-value">2<span class="stat-of">/4</span></p>
+        <p class="stat-value">{{ shipped_count }}<span class="stat-of">/{{ workstreams | length }}</span></p>
         <p class="stat-sub">shipped &middot; see status panel</p>
       </section>
 
@@ -94,48 +94,31 @@
       <section class="panel panel-status" aria-label="Rebuild status">
         <p class="panel-title">status</p>
         <ul class="status-list">
-          <li class="status-item is-done">
-            <span class="status-mark" aria-hidden="true">&#10003;</span>
-            <span class="status-label">design system</span>
-            <span class="status-state">shipped</span>
+          {% for item in workstreams %}
+          {% set state_class = {
+            'shipped': 'is-done', 'in progress': 'is-active'
+          }.get(item.state, 'is-queued') %}
+          {% set mark = {
+            'shipped': '&#10003;', 'in progress': '&#9656;'
+          }.get(item.state, '&#9675;') %}
+          <li class="status-item {{ state_class }}">
+            <span class="status-mark" aria-hidden="true">{{ mark | safe }}</span>
+            <span class="status-label">{{ item.label }}</span>
+            <span class="status-state">{{ item.state }}</span>
           </li>
-          <li class="status-item is-done">
-            <span class="status-mark" aria-hidden="true">&#10003;</span>
-            <span class="status-label">static build pipeline</span>
-            <span class="status-state">shipped</span>
-          </li>
-          <li class="status-item is-active">
-            <span class="status-mark" aria-hidden="true">&#9656;</span>
-            <span class="status-label">terraform + aws</span>
-            <span class="status-state">in progress</span>
-          </li>
-          <li class="status-item is-queued">
-            <span class="status-mark" aria-hidden="true">&#9675;</span>
-            <span class="status-label">cv, devops edition</span>
-            <span class="status-state">queued</span>
-          </li>
+          {% endfor %}
         </ul>
       </section>
 
       <section class="panel panel-target" aria-label="Next deployment target">
         <p class="panel-title">next deploy target</p>
         <dl class="target-list">
+          {% for row in deploy_target %}
           <div class="target-row">
-            <dt>compute</dt>
-            <dd>AWS EC2, free tier</dd>
+            <dt>{{ row.label }}</dt>
+            <dd>{{ row.value }}</dd>
           </div>
-          <div class="target-row">
-            <dt>provisioning</dt>
-            <dd>Terraform</dd>
-          </div>
-          <div class="target-row">
-            <dt>serving</dt>
-            <dd>gunicorn + nginx, Docker</dd>
-          </div>
-          <div class="target-row">
-            <dt>current host</dt>
-            <dd>GitHub Pages, static</dd>
-          </div>
+          {% endfor %}
         </dl>
       </section>
 

--- a/templates/construction.html
+++ b/templates/construction.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{{ config.brand_name }} | Site in transition</title>
-  <meta name="description" content="toucan.ee is being rebuilt around DevOps and platform engineering. A new, more focused site is on the way." />
+  <meta name="description" content="toucan.ee is being rebuilt around DevOps and platform engineering. Live rebuild board — a new, more focused site is on the way." />
 
   <link rel="canonical" href="{{ canonical_url }}" />
   <meta name="robots" content="noindex, nofollow" />
@@ -12,7 +12,7 @@
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="{{ config.brand_name }}" />
   <meta property="og:title" content="{{ config.brand_name }} | Site in transition" />
-  <meta property="og:description" content="Toucan is changing direction. A new, more focused site is on the way." />
+  <meta property="og:description" content="toucan.ee is being rebuilt around DevOps and platform engineering." />
   <meta property="og:url" content="{{ canonical_url }}" />
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -21,59 +21,127 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/construction.css', v=config.asset_version) }}" />
 </head>
 <body>
-  <div class="construction-shell">
-    <header class="site-header">
+  <div class="dash">
+    <header class="dash-topbar">
       <a class="wordmark" href="{{ canonical_url }}" aria-label="{{ config.brand_name }} home">
         toucan<span>.ee</span>
       </a>
-      <p class="site-state">Site in transition</p>
+      <p class="dash-state">
+        <span class="live-dot" aria-hidden="true"></span>
+        Site in transition &mdash; rebuild board
+      </p>
+      <p class="dash-updated">
+        {% if metrics.available %}
+        snapshot {{ metrics.generated_at.strftime('%Y-%m-%d %H:%M UTC') }}
+        {% else %}
+        static snapshot
+        {% endif %}
+      </p>
     </header>
 
-    <main class="construction-main">
-      <section class="construction-copy" aria-labelledby="construction-title">
-        <p class="eyebrow">Rebuild in progress</p>
+    <main class="dash-grid">
+      <section class="panel panel-intro" aria-labelledby="construction-title">
         <h1 id="construction-title">
-          <span class="headline-line headline-line-first">
-            <span class="headline-light">Changing</span>
-            <em>direction.</em>
-          </span>
-          <span class="headline-line headline-line-second">
-            <span>Building with</span>
-            <strong>intent.</strong>
-          </span>
+          <span class="headline-light">Changing direction.</span>
+          <strong>Building with intent.</strong>
         </h1>
         <p class="lede">
           I&rsquo;m {{ config.name }} &mdash; DevOps and platform engineering.
-          I&rsquo;m rebuilding toucan.ee as a live piece of infrastructure;
-          the full site lands soon.
+          This board is real: the numbers below are read from this site&rsquo;s
+          own repository every time it is built.
         </p>
+      </section>
 
-        <div class="deploy-log" aria-labelledby="deploy-log-title">
-          <p class="deploy-log-title" id="deploy-log-title">deploy log</p>
-          <ul class="deploy-log-list">
-            <li class="log-item is-done">
-              <span class="log-mark" aria-hidden="true">&#10003;</span>
-              <span class="log-label">design system</span>
-              <span class="log-state">shipped</span>
-            </li>
-            <li class="log-item is-done">
-              <span class="log-mark" aria-hidden="true">&#10003;</span>
-              <span class="log-label">static build pipeline</span>
-              <span class="log-state">shipped</span>
-            </li>
-            <li class="log-item is-active">
-              <span class="log-mark" aria-hidden="true">&#9656;</span>
-              <span class="log-label">terraform + aws</span>
-              <span class="log-state">in progress</span>
-            </li>
-            <li class="log-item is-queued">
-              <span class="log-mark" aria-hidden="true">&#9675;</span>
-              <span class="log-label">cv, devops edition</span>
-              <span class="log-state">queued</span>
-            </li>
-          </ul>
+      <section class="panel panel-stat" aria-label="Total commits">
+        <p class="panel-title">total commits</p>
+        <p class="stat-value">{{ metrics.total_commits if metrics.available else 'n/a' }}</p>
+        <p class="stat-sub">since first commit</p>
+      </section>
+
+      <section class="panel panel-stat" aria-label="Last activity">
+        <p class="panel-title">last activity</p>
+        <p class="stat-value stat-value--date">
+          {{ metrics.last_commit.strftime('%b %d') if metrics.last_commit else 'n/a' }}
+        </p>
+        <p class="stat-sub">
+          {{ metrics.last_commit.strftime('%Y, %H:%M %z') if metrics.last_commit else 'repo data unavailable' }}
+        </p>
+      </section>
+
+      <section class="panel panel-stat" aria-label="Rebuild progress">
+        <p class="panel-title">rebuild workstreams</p>
+        <p class="stat-value">2<span class="stat-of">/4</span></p>
+        <p class="stat-sub">shipped &middot; see status panel</p>
+      </section>
+
+      <section class="panel panel-activity" aria-label="Commit activity, last 12 weeks">
+        <p class="panel-title">commit activity &mdash; 12 weeks</p>
+        {% if metrics.weekly_bars %}
+        <div class="bar-chart" role="img" aria-label="Weekly commit counts for the last 12 weeks">
+          {% for height in metrics.weekly_bars %}
+          <span class="bar{% if loop.last %} bar--current{% endif %}" style="--h: {{ height }}%"></span>
+          {% endfor %}
         </div>
+        <p class="chart-legend">
+          <span>{{ metrics.weekly_commits | sum }} commits</span>
+          <span>peak {{ metrics.weekly_commits | max }}/wk</span>
+        </p>
+        {% else %}
+        <p class="panel-na">n/a &mdash; built without repository access</p>
+        {% endif %}
+      </section>
 
+      <section class="panel panel-status" aria-label="Rebuild status">
+        <p class="panel-title">status</p>
+        <ul class="status-list">
+          <li class="status-item is-done">
+            <span class="status-mark" aria-hidden="true">&#10003;</span>
+            <span class="status-label">design system</span>
+            <span class="status-state">shipped</span>
+          </li>
+          <li class="status-item is-done">
+            <span class="status-mark" aria-hidden="true">&#10003;</span>
+            <span class="status-label">static build pipeline</span>
+            <span class="status-state">shipped</span>
+          </li>
+          <li class="status-item is-active">
+            <span class="status-mark" aria-hidden="true">&#9656;</span>
+            <span class="status-label">terraform + aws</span>
+            <span class="status-state">in progress</span>
+          </li>
+          <li class="status-item is-queued">
+            <span class="status-mark" aria-hidden="true">&#9675;</span>
+            <span class="status-label">cv, devops edition</span>
+            <span class="status-state">queued</span>
+          </li>
+        </ul>
+      </section>
+
+      <section class="panel panel-target" aria-label="Next deployment target">
+        <p class="panel-title">next deploy target</p>
+        <dl class="target-list">
+          <div class="target-row">
+            <dt>compute</dt>
+            <dd>AWS EC2, free tier</dd>
+          </div>
+          <div class="target-row">
+            <dt>provisioning</dt>
+            <dd>Terraform</dd>
+          </div>
+          <div class="target-row">
+            <dt>serving</dt>
+            <dd>gunicorn + nginx, Docker</dd>
+          </div>
+          <div class="target-row">
+            <dt>current host</dt>
+            <dd>GitHub Pages, static</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section class="panel panel-contact" aria-label="Contact">
+        <p class="panel-title">contact</p>
+        <p class="contact-copy">Open to DevOps and platform work.</p>
         <div class="contact-row">
           <a class="contact-link" href="mailto:{{ config.email }}">
             Email me
@@ -91,8 +159,9 @@
       </section>
     </main>
 
-    <footer class="site-footer">
+    <footer class="dash-footer">
       <span>&copy; {{ current_year }} {{ config.brand_legal_name }}</span>
+      <span>values captured at build time &mdash; static by design</span>
     </footer>
   </div>
 </body>

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -78,6 +78,20 @@ def test_weekly_counts_ignore_commits_outside_window(monkeypatch):
     assert sum(counts) == 0
 
 
+def test_bar_heights_scales_to_peak():
+    assert metrics.bar_heights([0, 5, 10]) == [6, 50, 100]
+
+
+def test_bar_heights_keeps_zero_weeks_visible():
+    heights = metrics.bar_heights([0, 0, 1])
+    assert heights == [6, 6, 100]
+
+
+def test_bar_heights_handles_missing_data():
+    assert metrics.bar_heights(None) is None
+    assert metrics.bar_heights([]) is None
+
+
 def test_git_helper_swallows_missing_binary(monkeypatch):
     def raise_missing(*args, **kwargs):
         raise FileNotFoundError('git not installed')


### PR DESCRIPTION
## Summary
Implements #304 — the construction page becomes a dark, Grafana-inspired rebuild board rendering the real metrics from #305. Full takeover as decided: dashboard chrome, panel grid, mono-heavy type, single emerald accent.

## Panels
| Panel | Data | Source |
|---|---|---|
| Intro | headline + positioning | static copy |
| Total commits | **440** | `git rev-list` at build |
| Last activity | commit date/time | `git log -1` at build |
| Rebuild workstreams | 2/4 shipped | status list |
| Commit activity | 12-week bar chart | weekly histogram, `bar_heights()` |
| Next deploy target | EC2 · Terraform · gunicorn+nginx | epic #283 plan |
| Contact | email / LinkedIn / GitHub | SITE_CONFIG |

## Design notes
- Pure CSS bar chart (flex + custom property heights) — no JS, no chart lib
- All values render "n/a" when built without repo access (prod image path)
- Entrance stagger, live-dot pulse, and bar-grow animations only under `prefers-reduced-motion: no-preference`
- Panel grid collapses 12-col → mixed → single column at 900px/620px
- Footer states the honest caveat: "values captured at build time — static by design"

## Testing
- 35 passed (3 new for `bar_heights`); flake8 clean
- `test_home_page_is_construction_placeholder` constraints hold: one mailto, no `<img>`, "Site in transition" in the top bar
- Verified real rendered values in the dev container

Closes #304