### PR TITLE
release: Grafana palette + iOS contact-icon fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ dist/
 .claude/
 .junie/
 .impeccable.md
+.impeccable/
 skills-lock.json
 
 # OS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,16 +23,30 @@ To lint: `docker compose --profile ci run --rm tests flake8 .`
 
 Three distinct Flask applications share templates and content:
 
-1. **`app.py`** — Main public site. Routes: `/`, `/coming-soon/`, `/about/`, `/blog/<slug>/`, `/sitemap.xml`, `/robots.txt`. Site-wide config lives in `SITE_CONFIG` near the top, populated from env vars. `build_page_context()` assembles the template context for every `render_template` call. Page-level content data (`ABOUT_EXPERIENCE`, `COMING_SOON_TOPICS`) is defined as module-level constants and passed explicitly to templates — keep content out of templates.
+1. **`app.py`** — Main public site. Routes: `/` (construction dashboard), `/about/`, `/blog/`, `/blog/<slug>/`, `/privacy/`, `/sitemap.xml`, `/robots.txt`, and `POST /subscribe` (legacy, see below). Site-wide config lives in `SITE_CONFIG` near the top, populated from env vars. `build_page_context()` assembles the template context for every `render_template` call. Page-level content data is defined as module-level constants and passed explicitly to templates — keep content out of templates.
 
-2. **`freeze.py`** — Static site generator. Uses Flask's test client to render every route to HTML files in `build/`. Respects `GITHUB_PAGES_BASE_PATH` env var for subdirectory deployments. Production serves frozen output via Nginx or GitHub Pages.
+2. **`metrics.py`** — Build-time repo metrics for the construction dashboard (total commits, last commit, weekly commit sparkline). Runs `git` via subprocess; every value degrades to `None` (rendered as "n/a") when git or `.git` is missing. `BUILD_METRICS` is captured once at `app.py` import — on a static site, "telemetry" is whatever was true at build time. **Deploy gotcha:** the Pages workflow must check out with `fetch-depth: 0`, or a shallow clone bakes "total commits: 1".
 
-3. **`author_app.py`** + **`authoring_app/`** — CMS app (port 5001). Application factory in `authoring_app/__init__.py`. Routes in `authoring_app/views.py` under a Blueprint at `/authoring`. Handles Markdown post creation and media uploads. Not included in the public build.
+3. **`freeze.py`** — Static site generator. Uses Flask's test client to render every route to HTML files in `build/`. Requires `SITE_URL` to be set; respects `GITHUB_PAGES_BASE_PATH` for subdirectory deployments. Production serves frozen output via Nginx or GitHub Pages.
+
+4. **`author_app.py`** + **`authoring_app/`** — CMS app (port 5001). Application factory in `authoring_app/__init__.py`. Routes in `authoring_app/views.py` under a Blueprint at `/authoring`. Handles Markdown post creation and media uploads. Not included in the public build.
+
+### Current state: construction page
+
+The homepage (`/`) is a Grafana-style "site in transition" dashboard (`construction.html` + `CONSTRUCTION_PAGE` constant + `metrics.py` data) while the site pivots to a DevOps portfolio. The former CV homepage and mentoring holding page are retired.
+
+### Known dead code (pending cleanup)
+
+- `CV_PAGE` and `HOLDING_PAGE` constants in `app.py` (~290 lines) — referenced by nothing; `about.html` content is hardcoded
+- `POST /subscribe` + CSV subscriber helpers — only used by the retired holding page (and a frozen static site can't receive POSTs)
+- Templates with no rendering route: `holding.html`, `landing.html`, `index.html`, `coming-soon-launch.html`; plus `holding.css`, `landing.css`, `coming-soon.css`, `holding.js`
+
+Don't extend any of these; prefer deleting them (verify with grep + `make test` first).
 
 ### Templates
 
-- Most pages extend `base.html` using `{% block content %}`.
-- `coming-soon-full.html` is a **standalone** page — it does not extend `base.html` and has its own CSS (`static/css/coming-soon.css`).
+- Site pages (`about.html`, `privacy.html`, blog templates) extend `base.html` using `{% block content %}`.
+- `construction.html` is a **standalone** page — it does not extend `base.html`, has its own `<head>` (noindex, DM Sans + JetBrains Mono fonts), and uses `static/css/construction.css`.
 - No inline JavaScript in templates — all JS lives in `static/js/script.js`.
 
 ### CSS Architecture
@@ -42,32 +56,35 @@ Three distinct Flask applications share templates and content:
 - `components-core.css` — buttons, cards, home page, about page, company logos, contact form
 - `components-blog.css` — blog-specific styles
 
-`coming-soon.css` imports `base.css` directly and adds only page-specific styles. Do not duplicate CSS variables — add shared tokens to `base.css`.
+`construction.css` is standalone for the dashboard page. Do not duplicate CSS variables — add shared tokens to `base.css`. (`holding.css`, `landing.css`, `coming-soon.css` are dead — see above.)
 
 ### Blog Engine (`blog/`)
 
 - Posts are Markdown files in `content/posts/` with YAML front matter (`title`, `slug`, `date`, optional `hero_image`)
 - `blog/utils.py` handles parsing, rendering (with syntax highlighting), and metadata extraction
 - Content directory resolves via: `BLOG_CONTENT_DIR` → `AUTHORING_CONTENT_DIR` → `CONTENT_DIR` env vars → default `content/posts/`
+- `content/posts/` is currently empty — the engine works but has no published content yet
 
 ### Tests (`tests/`)
 
 - `conftest.py` reloads `app` fresh for each test run to avoid import-order side effects
-- Test files map 1:1 to source files: `test_app.py`, `test_authoring_app.py`, `test_blog_utils.py`, `test_freeze_utils.py`
+- Test files map 1:1 to source files: `test_app.py`, `test_authoring_app.py`, `test_blog_utils.py`, `test_freeze_utils.py`, `test_metrics.py`
 
 ### Environment
 
 - Copy `.env.example` to `.env.dev` for local dev
-- Key vars: `SITE_NAME`, `SITE_EMAIL`, `SITE_LOCATION`, `SITE_GITHUB_URL`, `SITE_LINKEDIN_URL`, `BASE_PATH`, `GITHUB_PAGES_BASE_PATH`
+- Key vars: `SITE_NAME`, `SITE_EMAIL`, `SITE_URL` (required by `freeze.py`), `SITE_GITHUB_URL`, `SITE_LINKEDIN_URL`, `BASE_PATH`, `GITHUB_PAGES_BASE_PATH`
 
 ## Git Commits
 
 Use [Conventional Commits](https://www.conventionalcommits.org/): `type(scope): description`  
 Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
 
+Never add `Co-Authored-By` trailers or attribution footers to commits or PR bodies.
+
 ## Branching Strategy
 
-- `master` is production — only updated via PR from `dev`
+- `master` is production — only updated via PR from `dev`; release PRs dev→master use **merge commits, never squash** (keeps histories aligned)
 - `dev` is the integration branch — all feature branches merge here
 - Branch naming: `type/issue-number-short-description` e.g. `feat/137-email-signup`
 - **Never** use auto-generated branch names like `claude/identify-project-bRvHV`
@@ -75,5 +92,5 @@ Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
 ## CI/CD
 
 GitHub Actions runs lint → tests → static build on PRs to `master`.  
-Deployment to GitHub Pages is manual (`workflow_dispatch`).  
+Deployment to GitHub Pages is manual (`workflow_dispatch`); the deploy checkout uses `fetch-depth: 0` so baked metrics see full history.  
 Workflows: `.github/workflows/ci.yml` and `deploy-pages.yml`.

--- a/static/css/construction.css
+++ b/static/css/construction.css
@@ -9,15 +9,20 @@
 
 :root {
   color-scheme: dark;
-  --bg: #0e1310;
-  --panel: #141a16;
-  --panel-raised: #17201b;
-  --line: #26302a;
-  --text: #e6ebe7;
-  --muted: #8fa096;
-  --accent: #5fd39a;
-  --accent-dim: color-mix(in srgb, var(--accent) 16%, transparent);
-  --focus: #8ae4b8;
+  /* Grafana dark theme: cool near-black canvas, faint borders, light-gray text */
+  --bg: #111217;
+  --panel: #181b1f;
+  --panel-raised: #1f2329;
+  --line: #2c3235;
+  --text: #ccccdc;
+  --muted: #8e909a;
+  --accent: #3d71d9;
+  --accent-dim: color-mix(in srgb, var(--accent) 18%, transparent);
+  --focus: #6e9fff;
+  /* Threshold palette (Grafana classic): status states */
+  --good: #73bf69;
+  --warn: #ff9830;
+  --warn-dim: color-mix(in srgb, var(--warn) 18%, transparent);
   --font-sans: "DM Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   --font-mono: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
 }
@@ -71,7 +76,8 @@ a {
 }
 
 .wordmark span {
-  color: var(--accent);
+  /* Lighter blue than --accent so the small bold wordmark clears WCAG AA */
+  color: var(--focus);
 }
 
 .dash-state,
@@ -296,11 +302,11 @@ a {
 }
 
 .status-item.is-done .status-mark {
-  color: var(--accent);
+  color: var(--good);
 }
 
 .status-item.is-active .status-mark {
-  color: var(--accent);
+  color: var(--warn);
 }
 
 .status-item.is-active .status-label {
@@ -310,8 +316,8 @@ a {
 .status-item.is-active .status-state {
   padding: 0.12rem 0.5rem;
   border-radius: 2px;
-  background: var(--accent-dim);
-  color: var(--accent);
+  background: var(--warn-dim);
+  color: var(--warn);
   font-weight: 600;
 }
 

--- a/static/css/construction.css
+++ b/static/css/construction.css
@@ -17,7 +17,6 @@
   --muted: #8fa096;
   --accent: #5fd39a;
   --accent-dim: color-mix(in srgb, var(--accent) 16%, transparent);
-  --accent-ink: #0d1f16;
   --focus: #8ae4b8;
   --font-sans: "DM Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   --font-mono: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
@@ -377,70 +376,30 @@ a {
   row-gap: 0.9rem;
 }
 
-.contact-link {
-  min-height: 2.75rem;
-  padding: 0 1.1rem;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.75rem;
-  border-radius: 2px;
-  background: var(--accent);
-  color: var(--accent-ink);
-  font-size: 0.85rem;
-  font-weight: 700;
-  line-height: 1;
-  text-decoration: none;
-  white-space: nowrap;
-  transition: opacity 180ms ease, transform 180ms cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.contact-link span {
-  font-size: 0.95rem;
-  transition: transform 180ms cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.contact-link:hover {
-  opacity: 0.88;
-}
-
-.contact-link:hover span {
-  transform: translate(0.16rem, -0.16rem);
-}
-
-.contact-link:active {
-  transform: translateY(1px);
-}
-
 .social-link {
+  width: 2.75rem;
+  height: 2.75rem;
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  padding-bottom: 0.15rem;
-  border-bottom: 1px solid var(--line);
-  color: var(--text);
-  font-size: 0.85rem;
-  font-weight: 600;
+  justify-content: center;
+  border: 1px solid var(--line);
+  border-radius: 2px;
+  color: var(--muted);
   text-decoration: none;
-  transition: border-color 180ms ease, color 180ms ease;
+  transition: color 180ms ease, border-color 180ms ease, background 180ms ease;
 }
 
-.social-link span {
-  color: var(--muted);
-  font-size: 0.78rem;
-  transition: transform 180ms cubic-bezier(0.16, 1, 0.3, 1);
+.social-icon {
+  display: block;
 }
 
 .social-link:hover {
   color: var(--accent);
   border-color: var(--accent);
-}
-
-.social-link:hover span {
-  transform: translate(0.12rem, -0.12rem);
+  background: var(--accent-dim);
 }
 
 .wordmark:focus-visible,
-.contact-link:focus-visible,
 .social-link:focus-visible {
   outline: 2px solid var(--focus);
   outline-offset: 3px;

--- a/templates/construction.html
+++ b/templates/construction.html
@@ -126,16 +126,21 @@
         <p class="panel-title">contact</p>
         <p class="contact-copy">Open to DevOps and platform work.</p>
         <div class="contact-row">
-          <a class="contact-link" href="mailto:{{ config.email }}">
-            Email me
-            <span aria-hidden="true">&#8599;</span>
+          <a class="social-link" href="mailto:{{ config.email }}" aria-label="Email">
+            <svg class="social-icon" viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true" focusable="false">
+              <path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z" />
+            </svg>
           </a>
-          <a class="social-link" href="{{ config.linkedin_url }}" target="_blank" rel="noopener">
-            LinkedIn <span aria-hidden="true">&#8599;</span>
+          <a class="social-link" href="{{ config.linkedin_url }}" target="_blank" rel="noopener" aria-label="LinkedIn">
+            <svg class="social-icon" viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true" focusable="false">
+              <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z" />
+            </svg>
           </a>
           {% if config.github_url %}
-          <a class="social-link" href="{{ config.github_url }}" target="_blank" rel="noopener">
-            GitHub <span aria-hidden="true">&#8599;</span>
+          <a class="social-link" href="{{ config.github_url }}" target="_blank" rel="noopener" aria-label="GitHub">
+            <svg class="social-icon" viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true" focusable="false">
+              <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+            </svg>
           </a>
           {% endif %}
         </div>


### PR DESCRIPTION
Release `dev` → `master` for the construction dashboard.

## Included
- **#315** Repaint to Grafana dark palette (cool #111217 canvas, blue accent, threshold status colors) + WCAG-AA wordmark contrast fix
- **#314** Replace iOS emoji arrows with inline SVG contact icons (Closes #309)
- **#313** CLAUDE.md refresh (docs)

## Notes
- Both feature PRs were code-reviewed on the way into `dev`.
- CSS/markup + docs only; `make test` green.
- Merge commit (not squash) to keep dev/master histories aligned.