### PR TITLE
content(dashboard): update deploy target copy for WSL2 self-host pivot

### DIFF
--- a/app.py
+++ b/app.py
@@ -114,12 +114,12 @@ CONSTRUCTION_PAGE = {
     'workstreams': [
         {'label': 'design system', 'state': 'shipped'},
         {'label': 'static build pipeline', 'state': 'shipped'},
-        {'label': 'terraform + aws', 'state': 'in progress'},
+        {'label': 'self-hosted deployment (wsl2)', 'state': 'in progress'},
         {'label': 'cv, devops edition', 'state': 'queued'},
     ],
     'deploy_target': [
-        {'label': 'compute', 'value': 'AWS EC2, free tier'},
-        {'label': 'provisioning', 'value': 'Terraform'},
+        {'label': 'compute', 'value': 'WSL2, Windows laptop'},
+        {'label': 'provisioning', 'value': 'Ansible'},
         {'label': 'serving', 'value': 'gunicorn + nginx, Docker'},
         {'label': 'current host', 'value': 'GitHub Pages, static'},
     ],


### PR DESCRIPTION
## Summary
The construction dashboard's deploy-target panel and workstream list still described the abandoned AWS/Terraform plan. Sprint 4 repivoted to self-hosting on the WSL2 laptop via Ansible (#283, #128, #282, #280) — this updates the copy to match.

- workstream: \`terraform + aws\` → \`self-hosted deployment (wsl2)\`
- compute: \`AWS EC2, free tier\` → \`WSL2, Windows laptop\`
- provisioning: \`Terraform\` → \`Ansible\`
- serving / current host: unchanged (still accurate)

## Test plan
- [x] \`make test\` — 29/29 passing