### PR TITLE
release: modularize app.py and remove hardcoded config defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,16 @@ jobs:
   verify:
     name: Lint, Test, Build Check
     runs-on: ubuntu-latest
+    env:
+      SITE_URL: ${{ vars.SITE_URL }}
+      BASE_PATH: ${{ vars.BASE_PATH }}
+      GITHUB_PAGES_BASE_PATH: ${{ vars.BASE_PATH }}
+      SITE_COMING_SOON: ${{ vars.SITE_COMING_SOON }}
+      SITE_GITHUB_URL: ${{ vars.SITE_GITHUB_URL }}
+      SITE_LINKEDIN_URL: ${{ vars.SITE_LINKEDIN_URL }}
+      SITE_IMDB_URL: ${{ vars.SITE_IMDB_URL }}
+      ASSET_VERSION: ${{ vars.ASSET_VERSION }}
+      SITE_SOCIAL_IMAGE: ${{ vars.SITE_SOCIAL_IMAGE }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -34,11 +44,6 @@ jobs:
         run: pytest
 
       - name: Build static site
-        env:
-          SITE_URL: ${{ vars.SITE_URL }}
-          BASE_PATH: ${{ vars.BASE_PATH }}
-          GITHUB_PAGES_BASE_PATH: ${{ vars.BASE_PATH }}
-          SITE_COMING_SOON: ${{ vars.SITE_COMING_SOON }}
         run: |
           set -euo pipefail
           python freeze.py

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -24,6 +24,8 @@ jobs:
       SITE_GITHUB_URL: ${{ vars.SITE_GITHUB_URL }}
       SITE_LINKEDIN_URL: ${{ vars.SITE_LINKEDIN_URL }}
       SITE_IMDB_URL: ${{ vars.SITE_IMDB_URL }}
+      ASSET_VERSION: ${{ vars.ASSET_VERSION }}
+      SITE_SOCIAL_IMAGE: ${{ vars.SITE_SOCIAL_IMAGE }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,10 @@ To lint: `docker compose --profile ci run --rm tests flake8 .`
 
 Three distinct Flask applications share templates and content:
 
-1. **`app.py`** — Main public site. Routes: `/` (construction dashboard), `/about/`, `/blog/`, `/blog/<slug>/`, `/sitemap.xml`, `/robots.txt`. Site-wide config lives in `SITE_CONFIG` near the top, populated from env vars. `build_page_context()` assembles the template context for every `render_template` call. Page-level content data is defined as module-level constants and passed explicitly to templates — keep content out of templates.
+1. **`app.py`** — Main public site. Routes: `/` (construction dashboard), `/about/`, `/blog/`, `/blog/<slug>/`, `/sitemap.xml`, `/robots.txt`. Flask init, the `icon()` Jinja global, `BUILD_METRICS`, `get_posts()`, and the route views only — config and content live in separate modules (below) and are imported in.
+
+   - **`config.py`** — `SITE_CONFIG` (populated from env vars), `NAV_LINKS`, `SITE_LINKS`, and the `build_absolute_url()` / `build_social_image_url()` / `build_page_context()` helpers. `build_page_context()` assembles the template context for every `render_template` call. `app.py` re-exports `SITE_CONFIG` for `freeze.py`.
+   - **`content/`** — page-level content as module-level constants (e.g. `content/construction.py`'s `CONSTRUCTION_PAGE`), passed explicitly to templates — keep content out of templates.
 
 2. **`metrics.py`** — Build-time repo metrics for the construction dashboard (total commits, last commit, weekly commit sparkline). Runs `git` via subprocess; every value degrades to `None` (rendered as "n/a") when git or `.git` is missing. `BUILD_METRICS` is captured once at `app.py` import — on a static site, "telemetry" is whatever was true at build time. **Deploy gotcha:** the Pages workflow must check out with `fetch-depth: 0`, or a shallow clone bakes "total commits: 1".
 

--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ app.config['TEMPLATES_AUTO_RELOAD'] = True
 from blog import find_post, load_posts, normalize_media_path  # noqa: E402
 from config import SITE_CONFIG  # noqa: E402,F401 (re-exported for freeze.py)
 from config import build_absolute_url, build_page_context  # noqa: E402
+from content.construction import CONSTRUCTION_PAGE  # noqa: E402
 from metrics import bar_heights, collect_metrics  # noqa: E402
 
 # Captured once at startup / freeze time — the static build bakes these
@@ -35,23 +36,6 @@ def _icon(name, size=16, label=None):
 
 
 app.jinja_env.globals['icon'] = _icon
-
-# Rebuild-board content for the construction dashboard. The workstream
-# stat panel derives shipped/total from this list — update it here only.
-CONSTRUCTION_PAGE = {
-    'workstreams': [
-        {'label': 'design system', 'state': 'shipped'},
-        {'label': 'static build pipeline', 'state': 'shipped'},
-        {'label': 'self-hosted deployment (wsl2)', 'state': 'in progress'},
-        {'label': 'cv, devops edition', 'state': 'queued'},
-    ],
-    'deploy_target': [
-        {'label': 'compute', 'value': 'WSL2, Windows laptop'},
-        {'label': 'provisioning', 'value': 'Ansible'},
-        {'label': 'serving', 'value': 'gunicorn + nginx, Docker'},
-        {'label': 'current host', 'value': 'GitHub Pages, static'},
-    ],
-}
 
 
 def get_posts():

--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from dotenv import load_dotenv
 from flask import (
-    Flask, abort, g, render_template, request, url_for,
+    Flask, abort, g, render_template, url_for,
 )
 from markupsafe import Markup
 
@@ -13,6 +13,8 @@ app = Flask(__name__)
 app.config['TEMPLATES_AUTO_RELOAD'] = True
 
 from blog import find_post, load_posts, normalize_media_path  # noqa: E402
+from config import SITE_CONFIG  # noqa: E402,F401 (re-exported for freeze.py)
+from config import build_absolute_url, build_page_context  # noqa: E402
 from metrics import bar_heights, collect_metrics  # noqa: E402
 
 # Captured once at startup / freeze time — the static build bakes these
@@ -34,80 +36,6 @@ def _icon(name, size=16, label=None):
 
 app.jinja_env.globals['icon'] = _icon
 
-SITE_CONFIG = {
-    'name': os.getenv('SITE_NAME', 'Sreyeesh Garimella'),
-    'brand_name': os.getenv('SITE_BRAND_NAME', 'Toucan Studios'),
-    'brand_legal_name': os.getenv('SITE_BRAND_LEGAL_NAME', 'Toucan Studios OÜ'),
-    'tagline': os.getenv(
-        'SITE_TAGLINE',
-        'Pipeline TD and Software Developer',
-    ),
-    'email': os.getenv('SITE_EMAIL', 'toucan.sg@gmail.com'),
-    'site_url': os.getenv('SITE_URL', '').rstrip('/'),
-    'meta_description': os.getenv(
-        'SITE_META_DESCRIPTION',
-        'CV and portfolio for Sreyeesh Garimella: Python tooling, workflow '
-        'automation, and production technology for animation, games, and beyond.',
-    ),
-    'asset_version': os.getenv('ASSET_VERSION', '1'),
-    'social_image': os.getenv('SITE_SOCIAL_IMAGE', 'images/SreyeeshProfilePic.jpg'),
-    'github_url': os.getenv('SITE_GITHUB_URL', 'https://github.com/Sreyeesh'),
-    'linkedin_url': os.getenv(
-        'SITE_LINKEDIN_URL',
-        'https://www.linkedin.com/in/sreyeeshgarimella',
-    ),
-    'imdb_url': os.getenv('SITE_IMDB_URL', ''),
-    'location': os.getenv('SITE_LOCATION', 'Estonia'),
-}
-
-NAV_LINKS = [
-    {'label': 'Home', 'href': '/', 'slug': 'home'},
-    {'label': 'Writing', 'href': '/blog/', 'slug': 'blog'},
-    {'label': 'About', 'href': '/about/', 'slug': 'about'},
-]
-
-SITE_LINKS = {
-    'home': '/',
-    'blog': '/blog/',
-    'about': '/about/',
-}
-
-
-def get_posts():
-    if 'posts' not in g:
-        g.posts = load_posts()
-    return g.posts
-
-
-def build_absolute_url(path: str) -> str:
-    site_url = SITE_CONFIG['site_url']
-    normalized = path if path.startswith('/') else f'/{path}'
-    if site_url:
-        return f'{site_url}{normalized}'
-    return f'{request.url_root.rstrip("/")}{normalized}'
-
-
-def build_social_image_url() -> str:
-    social_image = SITE_CONFIG['social_image']
-    if social_image.startswith(('http://', 'https://')):
-        return social_image
-    static_path = url_for('static', filename=social_image)
-    return build_absolute_url(static_path)
-
-
-def build_page_context(**extra) -> dict:
-    context = {
-        'config': SITE_CONFIG,
-        'current_year': datetime.now().year,
-        'nav_links': NAV_LINKS,
-        'site_links': SITE_LINKS,
-        'canonical_url': build_absolute_url(request.path),
-        'social_image_url': build_social_image_url(),
-    }
-    context.update(extra)
-    return context
-
-
 # Rebuild-board content for the construction dashboard. The workstream
 # stat panel derives shipped/total from this list — update it here only.
 CONSTRUCTION_PAGE = {
@@ -124,6 +52,12 @@ CONSTRUCTION_PAGE = {
         {'label': 'current host', 'value': 'GitHub Pages, static'},
     ],
 }
+
+
+def get_posts():
+    if 'posts' not in g:
+        g.posts = load_posts()
+    return g.posts
 
 
 @app.route('/')

--- a/config.py
+++ b/config.py
@@ -18,13 +18,10 @@ SITE_CONFIG = {
         'CV and portfolio for Sreyeesh Garimella: Python tooling, workflow '
         'automation, and production technology for animation, games, and beyond.',
     ),
-    'asset_version': os.getenv('ASSET_VERSION', '1'),
-    'social_image': os.getenv('SITE_SOCIAL_IMAGE', 'images/SreyeeshProfilePic.jpg'),
-    'github_url': os.getenv('SITE_GITHUB_URL', 'https://github.com/Sreyeesh'),
-    'linkedin_url': os.getenv(
-        'SITE_LINKEDIN_URL',
-        'https://www.linkedin.com/in/sreyeeshgarimella',
-    ),
+    'asset_version': os.getenv('ASSET_VERSION', ''),
+    'social_image': os.getenv('SITE_SOCIAL_IMAGE', ''),
+    'github_url': os.getenv('SITE_GITHUB_URL', ''),
+    'linkedin_url': os.getenv('SITE_LINKEDIN_URL', ''),
     'imdb_url': os.getenv('SITE_IMDB_URL', ''),
     'location': os.getenv('SITE_LOCATION', 'Estonia'),
 }

--- a/config.py
+++ b/config.py
@@ -1,0 +1,71 @@
+import os
+from datetime import datetime
+
+from flask import request, url_for
+
+SITE_CONFIG = {
+    'name': os.getenv('SITE_NAME', 'Sreyeesh Garimella'),
+    'brand_name': os.getenv('SITE_BRAND_NAME', 'Toucan Studios'),
+    'brand_legal_name': os.getenv('SITE_BRAND_LEGAL_NAME', 'Toucan Studios OÜ'),
+    'tagline': os.getenv(
+        'SITE_TAGLINE',
+        'Pipeline TD and Software Developer',
+    ),
+    'email': os.getenv('SITE_EMAIL', 'toucan.sg@gmail.com'),
+    'site_url': os.getenv('SITE_URL', '').rstrip('/'),
+    'meta_description': os.getenv(
+        'SITE_META_DESCRIPTION',
+        'CV and portfolio for Sreyeesh Garimella: Python tooling, workflow '
+        'automation, and production technology for animation, games, and beyond.',
+    ),
+    'asset_version': os.getenv('ASSET_VERSION', '1'),
+    'social_image': os.getenv('SITE_SOCIAL_IMAGE', 'images/SreyeeshProfilePic.jpg'),
+    'github_url': os.getenv('SITE_GITHUB_URL', 'https://github.com/Sreyeesh'),
+    'linkedin_url': os.getenv(
+        'SITE_LINKEDIN_URL',
+        'https://www.linkedin.com/in/sreyeeshgarimella',
+    ),
+    'imdb_url': os.getenv('SITE_IMDB_URL', ''),
+    'location': os.getenv('SITE_LOCATION', 'Estonia'),
+}
+
+NAV_LINKS = [
+    {'label': 'Home', 'href': '/', 'slug': 'home'},
+    {'label': 'Writing', 'href': '/blog/', 'slug': 'blog'},
+    {'label': 'About', 'href': '/about/', 'slug': 'about'},
+]
+
+SITE_LINKS = {
+    'home': '/',
+    'blog': '/blog/',
+    'about': '/about/',
+}
+
+
+def build_absolute_url(path: str) -> str:
+    site_url = SITE_CONFIG['site_url']
+    normalized = path if path.startswith('/') else f'/{path}'
+    if site_url:
+        return f'{site_url}{normalized}'
+    return f'{request.url_root.rstrip("/")}{normalized}'
+
+
+def build_social_image_url() -> str:
+    social_image = SITE_CONFIG['social_image']
+    if social_image.startswith(('http://', 'https://')):
+        return social_image
+    static_path = url_for('static', filename=social_image)
+    return build_absolute_url(static_path)
+
+
+def build_page_context(**extra) -> dict:
+    context = {
+        'config': SITE_CONFIG,
+        'current_year': datetime.now().year,
+        'nav_links': NAV_LINKS,
+        'site_links': SITE_LINKS,
+        'canonical_url': build_absolute_url(request.path),
+        'social_image_url': build_social_image_url(),
+    }
+    context.update(extra)
+    return context

--- a/content/construction.py
+++ b/content/construction.py
@@ -1,0 +1,16 @@
+# Rebuild-board content for the construction dashboard. The workstream
+# stat panel derives shipped/total from this list — update it here only.
+CONSTRUCTION_PAGE = {
+    'workstreams': [
+        {'label': 'design system', 'state': 'shipped'},
+        {'label': 'static build pipeline', 'state': 'shipped'},
+        {'label': 'self-hosted deployment (wsl2)', 'state': 'in progress'},
+        {'label': 'cv, devops edition', 'state': 'queued'},
+    ],
+    'deploy_target': [
+        {'label': 'compute', 'value': 'WSL2, Windows laptop'},
+        {'label': 'provisioning', 'value': 'Ansible'},
+        {'label': 'serving', 'value': 'gunicorn + nginx, Docker'},
+        {'label': 'current host', 'value': 'GitHub Pages, static'},
+    ],
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,8 @@ services:
     working_dir: /app
     environment:
       - PYTHONDONTWRITEBYTECODE=1
+    env_file:
+      - .env.dev
     restart: "no"
 
 networks:


### PR DESCRIPTION
Release PR dev → master.

## Summary
Merges #326:
- Splits `app.py` into `config.py` (site config + context helpers) and `content/construction.py` (dashboard content), closing #321
- Updates `CLAUDE.md`'s Architecture section for the new module layout
- Removes hardcoded personal defaults (GitHub/LinkedIn URLs, social image path, asset version) from `config.py` — values now come entirely from env vars / GitHub repo variables, which are already set to match the old defaults
- Wires the previously-missing env vars through `ci.yml`, `deploy-pages.yml`, and `docker-compose.yml`'s `tests` service so CI/deploy/local test runs all resolve config the same way

No visible behavior change — production repo variables match the old hardcoded defaults exactly.

## Test plan
- [x] make test — 29/29 passing
- [x] flake8 clean
- [x] make freeze — confirmed identical output (asset_version=1 baked in correctly)
- [x] CI green on PR #326