### PR TITLE
fix(content): avoid contact copy dict collision

### DIFF
--- a/content/pages/construction.toml
+++ b/content/pages/construction.toml
@@ -41,7 +41,7 @@ title = "next deploy target"
 
 [contact]
 title = "contact"
-copy = "Open to DevOps and platform work."
+body = "Open to DevOps and platform work."
 
 [footer]
 snapshot_note = "values captured at build time — static by design"

--- a/templates/construction.html
+++ b/templates/construction.html
@@ -128,7 +128,7 @@
 
       <section class="panel panel-contact" aria-label="Contact">
         <p class="panel-title">{{ construction.contact.title }}</p>
-        <p class="contact-copy">{{ construction.contact.copy }}</p>
+        <p class="contact-copy">{{ construction.contact.body }}</p>
         <div class="contact-row">
           <a class="social-link" href="mailto:{{ config.email }}" aria-label="Email">
             <svg class="social-icon" viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true" focusable="false">

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -16,6 +16,8 @@ def test_home_page_is_construction_placeholder(client):
     assert b'Site in transition' in body
     assert b'<img' not in body
     assert body.count(b'mailto:') == 1
+    assert b'Open to DevOps and platform work.' in body
+    assert b'<built-in method copy' not in body
     # It must not be the old mentoring waitlist or CV/portfolio homepage.
     assert b'1-on-1 Mentoring' not in body
     assert b'waitlist' not in body


### PR DESCRIPTION
## Summary
- rename construction contact content key from copy to body
- update the dashboard template to render contact.body
- add a homepage regression check so the dict copy method does not render

## Verification
- docker compose run --rm tests pytest tests/test_app.py::test_home_page_is_construction_placeholder
- docker compose run --rm tests
- docker compose --profile ci run --rm tests flake8 .

Addresses #330.