### PR TITLE
fix(docker): pass SITE_URL into production build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.11-slim
 
 # Allow overriding the URL base path (useful for GitHub Pages)
 ARG BASE_PATH=/mentor-site
+ARG SITE_URL=
 
 # Set working directory
 WORKDIR /app
@@ -15,6 +16,7 @@ ENV FLASK_ENV=production
 ENV PYTHONPATH=/app
 ENV BASE_PATH=${BASE_PATH}
 ENV GITHUB_PAGES_BASE_PATH=${BASE_PATH}
+ENV SITE_URL=${SITE_URL}
 
 # Install system dependencies
 RUN apt-get update \

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ test:
 docker-build: freeze
 	$(DOCKER) build \
 		--build-arg BASE_PATH=$$(grep -m1 BASE_PATH .env | cut -d'=' -f2-) \
+		--build-arg SITE_URL=$$(grep -m1 SITE_URL .env | cut -d'=' -f2-) \
 		-t toucan-ee .
 
 docker-up:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
       context: .
       args:
         BASE_PATH: ${BASE_PATH:-/}
+        SITE_URL: ${SITE_URL:-}
     container_name: toucan-ee-prod
     ports:
       # Map configurable host port to container port 80 (nginx)

--- a/docs/MAKEFILE.md
+++ b/docs/MAKEFILE.md
@@ -27,7 +27,7 @@ Toucan.ee workflow targets:
 | `make run` / `make docker-dev` | `docker compose --profile dev up toucan-ee-dev` | Launch the Flask dev server with live reload on port 5000. Uses `.env.dev` by default. |
 | `make freeze`   | `ENV_FILE=.env docker compose --profile dev run --rm toucan-ee-dev python freeze.py` | Generate the static site with production env vars inside the dev container. Automatically runs before `make docker-build`. |
 | `make test`     | `docker compose run --rm tests` | Execute the Pytest suite inside the dedicated test container. |
-| `make docker-build` | `docker build … -t toucan-ee .` (after `make freeze`) | Create the production image. Pulls `BASE_PATH` from `.env`. |
+| `make docker-build` | `docker build … -t toucan-ee .` (after `make freeze`) | Create the production image. Pulls `BASE_PATH` and `SITE_URL` from `.env`. |
 | `make docker-up` | `docker compose up --build toucan-ee` | Run the production-style nginx container locally on port 3000. Good for staging/testing the static build. |
 | `make authoring` | `docker compose --profile authoring up authoring-tool` | Start the CMS/authoring tool on port 5001 to edit blog posts via the UI. |
 | `make down`     | `docker compose down` | Stop every running service defined in `docker-compose.yml`. |

--- a/tests/test_docker_config.py
+++ b/tests/test_docker_config.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_production_docker_build_receives_site_url():
+    dockerfile = (ROOT / 'Dockerfile').read_text(encoding='utf-8')
+    freeze_step = dockerfile.index('RUN python freeze.py')
+
+    assert dockerfile.index('ARG SITE_URL=') < freeze_step
+    assert dockerfile.index('ENV SITE_URL=${SITE_URL}') < freeze_step
+
+
+def test_compose_passes_site_url_as_build_arg():
+    compose = (ROOT / 'docker-compose.yml').read_text(encoding='utf-8')
+
+    assert 'SITE_URL: ${SITE_URL:-}' in compose
+
+
+def test_make_docker_build_passes_site_url_as_build_arg():
+    makefile = (ROOT / 'Makefile').read_text(encoding='utf-8')
+
+    assert '--build-arg SITE_URL=$$(grep -m1 SITE_URL .env | cut -d' in makefile


### PR DESCRIPTION
## Summary
- pass SITE_URL into the production Docker build through compose and Makefile build args
- expose SITE_URL in the Dockerfile before freeze.py runs
- add regression tests for the Docker/compose/Makefile build wiring
- update Makefile docs for the production image build args

## Verification
- docker compose run --rm tests pytest tests/test_docker_config.py
- docker compose run --rm tests
- docker compose --profile ci run --rm tests flake8 .
- docker compose build toucan-ee

Fixes #329.