### PR TITLE
release: refresh dashboard deployment status

### DIFF
--- a/content/pages/construction.toml
+++ b/content/pages/construction.toml
@@ -24,7 +24,7 @@ unavailable = "repo data unavailable"
 
 [stats.rebuild_progress]
 label = "rebuild workstreams"
-subtext = "shipped · see status panel"
+subtext = "current snapshot · see status panel"
 
 [activity]
 title = "commit activity — 12 weeks"
@@ -37,7 +37,7 @@ peak_label = "peak"
 title = "status"
 
 [target]
-title = "next deploy target"
+title = "current deployment"
 
 [contact]
 title = "contact"
@@ -55,25 +55,25 @@ label = "static build pipeline"
 state = "shipped"
 
 [[workstreams]]
-label = "self-hosted deployment (wsl2)"
-state = "in progress"
+label = "content/config cleanup"
+state = "shipped"
 
 [[workstreams]]
-label = "cv, devops edition"
-state = "queued"
+label = "production deploy path"
+state = "shipped"
 
 [[deploy_target]]
-label = "compute"
-value = "WSL2, Windows laptop"
+label = "production host"
+value = "GitHub Pages"
 
 [[deploy_target]]
-label = "provisioning"
-value = "Ansible"
+label = "site format"
+value = "frozen static HTML"
 
 [[deploy_target]]
-label = "serving"
-value = "gunicorn + nginx, Docker"
+label = "deploy trigger"
+value = "manual GitHub Actions workflow"
 
 [[deploy_target]]
-label = "current host"
-value = "GitHub Pages, static"
+label = "local preview"
+value = "Docker + nginx"

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -12,7 +12,7 @@ def test_load_page_reads_page_content():
     data = load_page('construction')
 
     assert data['topbar']['state_label'] == 'Site in transition — rebuild board'
-    assert data['deploy_target'][0]['label'] == 'compute'
+    assert data['deploy_target'][0]['label'] == 'production host'
 
 
 def test_site_content_contains_defaults_and_nav():


### PR DESCRIPTION
## Summary
- promote the dashboard deployment status copy fix to production
- updates the rebuild workstreams from 2/4 to current 4/4 shipped state
- replaces stale WSL2 next-deploy copy with current GitHub Pages deployment details

## Verification
- PR #341 CI passed
- local targeted tests passed
- local full test suite passed
- local flake8 passed

Deploy after merge by running the Deploy to GitHub Pages workflow on master.